### PR TITLE
Rename group to group_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tabeline is a data table and data grammar library. You write the expressions in strings and supply them to methods on the `DataTable` class. The  strings are parsed by Parsita and converted into Polars for execution.
 
-Tabeline draws inspiration from dplyr, the data grammar of R's tidyverse, especially for its methods names. The `filter`, `mutate`, `group`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipes, like is standard in R. 
+Tabeline draws inspiration from dplyr, the data grammar of R's tidyverse, especially for its methods names. The `filter`, `mutate`, `group_by`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipes, like is standard in R. 
 
 Tabeline uses Polars under the hood, but adds a lot of handling of edge cases from Polars, which otherwise result in crashes or behavior that is not type stable.
 
@@ -34,7 +34,7 @@ table = DataTable(
 analysis = (
     table
     .filter("t <= 24")
-    .group("id")
+    .group_by("id")
     .summarize(auc="trapz(t, y)")
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Tabeline is a data table and data grammar library. You write the expressions in strings and supply them to methods on the `DataTable` class, like `table.filter("t <= 24")`. The  strings are parsed by Parsita and converted into Polars for execution.
 
-Tabeline draws inspiration from [dplyr](https://dplyr.tidyverse.org/), the data grammar of R's tidyverse. The `filter`, `mutate`, `group`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipe operators. 
+Tabeline draws inspiration from [dplyr](https://dplyr.tidyverse.org/), the data grammar of R's tidyverse. The `filter`, `mutate`, `group_by`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipe operators. 
 
 Tabeline uses Polars under the hood, but adds a lot of handling of edge cases from Polars, which otherwise result in crashes or behavior that is not type stable.
 
@@ -32,7 +32,7 @@ table = DataTable(
 analysis = (
     table
     .filter("t <= 24")
-    .group("id")
+    .group_by("id")
     .summarize(auc="trapz(t, y)")
 )
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -41,8 +41,8 @@ Each verb is a method of `DataTable`.
 
 ### Grouping
 
-* [`group`](verbs/group.md#group): Create a group level containing given columns
-* [`ungroup`](verbs/group.md#ungroup): Drop the last group level
+* [`group_by`](verbs/group_by.md#group_by): Create a group level containing given columns
+* [`ungroup`](verbs/group_by.md#ungroup): Drop the last group level
 
 ### Summarizing
 

--- a/docs/verbs/group_by.md
+++ b/docs/verbs/group_by.md
@@ -1,10 +1,10 @@
 # Grouping
 
-`group` is not so much a verb as it is a preposition. `group` does not change the contents or orders of any rows or columns, but it changes the context of subsequent verbs. All rows which have the same values in all group columns are members of the same subtable. Subsequent verbs act as if they are applied each subtable individually. So in `filter` or `mutate`, an expression containing `max` or `mean` will apply only to the rows in each subtable. 
+`group_by` is not so much a verb as it is a preposition. `group_by` does not change the contents or orders of any rows or columns, but it changes the context of subsequent verbs. All rows which have the same values in all group_by columns are members of the same subtable. Subsequent verbs act as if they are applied each subtable individually. So in `filter` or `mutate`, an expression containing `max` or `mean` will apply only to the rows in each subtable. 
 
-Tabeline is different from all popular data grammar libraries in how it handles groups. An instance of `DataTable` has group levels. Each invocation of `group` adds one group level, which can contain any number of columns names by which to group. The flattened list of group names from all levels can be accessed via the `group_names` property.
+Tabeline is different from all popular data grammar libraries in how it handles groups. An instance of `DataTable` has group levels. Each invocation of `group_by` adds one group level, which can contain any number of columns names by which to group. The flattened list of group names from all levels can be accessed via the `group_names` property.
 
-## `group`
+## `group_by`
 
 Add a set of column names as a new group level. The column names must exist, and they must not be previously grouped.
 
@@ -16,7 +16,7 @@ table = DataTable(
     x = [1, 2, 3, 4],
 )
 
-table.group("id").mutate(mean="mean(x)")
+table.group_by("id").mutate(mean="mean(x)")
 # group levels: [id]
 # shape: (4, 3)
 # ┌─────┬─────┬──────┐
@@ -48,7 +48,7 @@ table = DataTable(
     x = [1, 2, 3, 4],
 )
 
-table.group("id").mutate(mean="mean(x)")
+table.group_by("id").mutate(mean="mean(x)")
 # shape: (4, 3)
 # ┌─────┬─────┬──────┐
 # │ id  ┆ x   ┆ mean │

--- a/docs/verbs/spread.md
+++ b/docs/verbs/spread.md
@@ -15,7 +15,7 @@ table = DataTable(
     grades=[0, 0, 1, 1, 2, 2], sex=["M", "F", "M", "F", "M", "F"], count=[8, 9, 9, 10, 6, 9]
 )
 
-table.group("sex").spread("grades", "count")
+table.group_by("sex").spread("grades", "count")
 # shape: (2, 4)
 # ┌─────┬─────┬─────┬─────┐
 # │ sex ┆ 0   ┆ 1   ┆ 2   │

--- a/docs/verbs/summarize.md
+++ b/docs/verbs/summarize.md
@@ -12,7 +12,7 @@ table = DataTable(
     x = [1, 2, 3, 4],
 )
 
-table.group("id").summarize(x = "mean(x)")
+table.group_by("id").summarize(x="mean(x)")
 # shape: (2, 2)
 # ┌─────┬─────┐
 # │ id  ┆ x   │

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
     - Filtering: verbs/filter.md
     - Sorting: verbs/sort.md
     - Mutation: verbs/mutate.md
-    - Grouping: verbs/group.md
+    - Grouping: verbs/group_by.md
     - Summarizing: verbs/summarize.md
     - Reshaping: verbs/spread.md
     - Joining: verbs/join.md

--- a/src/tabeline/_data_table.py
+++ b/src/tabeline/_data_table.py
@@ -372,7 +372,7 @@ class DataTable:
         # of group columns followed by explicit columns
         return mutated_table.select(*self.group_names, *mutators.keys())
 
-    def group(
+    def group_by(
         self, *columns: str, order: Literal["original", "cluster", "sort"] = "original"
     ) -> DataTable:
         assert_legal_columns(columns, self.column_names, self.group_names)
@@ -389,6 +389,9 @@ class DataTable:
             )
 
         return DataTable(ordered_table._df, self.group_levels + (columns,), self.height)
+
+    def group(self, *columns: str, order: Literal["original", "cluster", "sort"] = "original") -> DataTable:
+        return self.group_by(*columns, order=order)
 
     def ungroup(self) -> DataTable:
         if len(self.group_levels) == 0:
@@ -447,7 +450,7 @@ class DataTable:
             id_vars=all_columns, value_vars=list(columns), variable_name=key, value_name=value
         )
 
-        return DataTable(df, self.group_levels).group(key)
+        return DataTable(df, self.group_levels).group_by(key)
 
     def _resolve_join_by(
         self,
@@ -588,7 +591,7 @@ class DataTable:
 
     def __repr__(self):
         column_strs = [f"{name} = {list(values)!r}" for name, values in self._df.to_dict().items()]
-        group_strs = [f".group({', '.join(map(repr, level))})" for level in self.group_levels]
+        group_strs = [f".group_by({', '.join(map(repr, level))})" for level in self.group_levels]
         return f"DataTable({', '.join(column_strs)}){''.join(group_strs)}"
 
     def __str__(self):

--- a/tests/_grouping.py
+++ b/tests/_grouping.py
@@ -5,5 +5,5 @@ from tabeline import DataTable
 
 def apply_groups(table: DataTable, group_levels: tuple[tuple[str, ...], ...]) -> DataTable:
     for group_level in group_levels:
-        table = table.group(*group_level)
+        table = table.group_by(*group_level)
     return table

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -18,9 +18,9 @@ def test_cluster_two():
 
 
 def test_cluster_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6]).group("x")
+    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6]).group_by("x")
     actual = table.cluster("y")
-    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 4, 3, 4, 4], z=[1, 6, 3, 4, 2, 5]).group(
+    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 4, 3, 4, 4], z=[1, 6, 3, 4, 2, 5]).group_by(
         "x"
     )
     assert actual == expected
@@ -29,11 +29,11 @@ def test_cluster_grouped():
 def test_cluster_grouped_two():
     table = DataTable(
         x=[2, 2, 1, 1, 2, 2, 2], y=[3, 4, 4, 4, 4, 3, 4], z=[2, 1, 1, 1, 2, 1, 1]
-    ).group("x", "y")
+    ).group_by("x", "y")
     actual = table.cluster("z")
     expected = DataTable(
         x=[2, 2, 1, 1, 2, 2, 2], y=[3, 4, 4, 4, 4, 3, 4], z=[2, 1, 1, 1, 1, 1, 2]
-    ).group("x", "y")
+    ).group_by("x", "y")
     assert actual == expected
 
 
@@ -41,8 +41,8 @@ def test_cluster_grouped_two():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_cluster_empty(table):
@@ -54,8 +54,8 @@ def test_cluster_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_cluster_columnless(table):
@@ -68,11 +68,11 @@ def test_cluster_columnless(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[], z=[]).group(),
-        DataTable(x=[], y=[], z=[]).group().group(),
-        DataTable(x=[], y=[], z=[]).group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("w").group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("x", "w"),
+        DataTable(x=[], y=[], z=[]).group_by(),
+        DataTable(x=[], y=[], z=[]).group_by().group_by(),
+        DataTable(x=[], y=[], z=[]).group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "w"),
     ],
 )
 def test_cluster_rowless(columns, table):

--- a/tests/test_deselect.py
+++ b/tests/test_deselect.py
@@ -64,7 +64,7 @@ def test_deselect_nonexistent_column():
 
 
 def test_deselect_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
 
     with pytest.raises(GroupColumn):
         _ = table.deselect("x")
@@ -74,8 +74,8 @@ def test_deselect_group_column():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_deselect_empty(table):
@@ -87,8 +87,8 @@ def test_deselect_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_deselect_columnless(table):

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -28,9 +28,9 @@ def test_empty_distinct():
 def test_distinct_with_grouped_column(distinct_columns):
     table = DataTable(
         x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
-    ).group("x")
+    ).group_by("x")
     actual = table.distinct(*distinct_columns)
-    expected = DataTable(x=[0, 1, 1, 1], y=["a", "a", "a", "b"], z=[1, 1, 2, 3]).group("x")
+    expected = DataTable(x=[0, 1, 1, 1], y=["a", "a", "a", "b"], z=[1, 1, 2, 3]).group_by("x")
     assert actual == expected
 
 
@@ -38,9 +38,9 @@ def test_distinct_with_grouped_column(distinct_columns):
 def test_distinct_with_two_grouped_columns(distinct_columns):
     table = DataTable(
         x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
-    ).group("x", "y")
+    ).group_by("x", "y")
     actual = table.distinct(*distinct_columns)
-    expected = DataTable(x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3]).group(
+    expected = DataTable(x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3]).group_by(
         "x", "y"
     )
     assert actual == expected
@@ -52,14 +52,14 @@ def test_distinct_with_two_separate_grouped_columns(distinct_columns):
         DataTable(
             x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
         )
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
     )
     actual = table.distinct(*distinct_columns)
     expected = (
         DataTable(x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3])
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
     )
     assert actual == expected
 
@@ -68,8 +68,8 @@ def test_distinct_with_two_separate_grouped_columns(distinct_columns):
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_distinct_on_empty(table):
@@ -82,8 +82,8 @@ def test_distinct_on_empty(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group(),
-        DataTable(x=[], y=[]).group().group(),
+        DataTable(x=[], y=[]).group_by(),
+        DataTable(x=[], y=[]).group_by().group_by(),
     ],
 )
 def test_distinct_on_rowless(columns, table):
@@ -95,10 +95,10 @@ def test_distinct_on_rowless(columns, table):
     ["table", "expected"],
     [
         [DataTable.columnless(height=6), DataTable.columnless(height=1)],
-        [DataTable.columnless(height=6).group(), DataTable.columnless(height=1).group()],
+        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=1).group_by()],
         [
-            DataTable.columnless(height=6).group().group(),
-            DataTable.columnless(height=1).group().group(),
+            DataTable.columnless(height=6).group_by().group_by(),
+            DataTable.columnless(height=1).group_by().group_by(),
         ],
     ],
 )

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -64,20 +64,20 @@ def test_reordered_columns_are_not_equal():
 
 
 def test_grouped_tables_are_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group(
+    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group_by(
         "x"
     )
-    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group(
+    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group_by(
         "x"
     )
     assert first == second
 
 
 def test_grouped_tables_with_differnt_levels_are_not_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group(
+    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group_by(
         "x"
     )
-    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group(
+    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]).group_by(
         "y"
     )
     assert first != second

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -11,9 +11,9 @@ def test_filter():
 
 
 def test_grouped_filter():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group("x")
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
     actual = table.filter("y == max(y)")
-    expected = DataTable(x=[0, 1, 1], y=[2, 3, 3]).group("x")
+    expected = DataTable(x=[0, 1, 1], y=[2, 3, 3]).group_by("x")
     assert actual == expected
 
 
@@ -28,11 +28,11 @@ def test_filter_out_all_rows():
     "table",
     [
         DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group("x"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group("x", "y"),
+        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
+        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
         DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
-        .group("x")
-        .group("y"),
+        .group_by("x")
+        .group_by("y"),
     ],
 )
 def test_filter_true(table):
@@ -44,11 +44,11 @@ def test_filter_true(table):
     "table",
     [
         DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group("x"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group("x", "y"),
+        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
+        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
         DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
-        .group("x")
-        .group("y"),
+        .group_by("x")
+        .group_by("y"),
     ],
 )
 def test_filter_false(table):
@@ -62,8 +62,8 @@ def test_filter_false(table):
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_filter_empty(expression, table):
@@ -75,10 +75,10 @@ def test_filter_empty(expression, table):
     ["table", "expected"],
     [
         [DataTable.columnless(height=6), DataTable.columnless(height=3)],
-        [DataTable.columnless(height=6).group(), DataTable.columnless(height=3).group()],
+        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=3).group_by()],
         [
-            DataTable.columnless(height=6).group().group(),
-            DataTable.columnless(height=3).group().group(),
+            DataTable.columnless(height=6).group_by().group_by(),
+            DataTable.columnless(height=3).group_by().group_by(),
         ],
     ],
 )
@@ -92,11 +92,11 @@ def test_filter_columnless(table, expected):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group(),
-        DataTable(x=[]).group().group(),
-        DataTable(x=[], y=[], z=[]).group("x"),
-        DataTable(x=[], y=[], z=[]).group("x", "y"),
-        DataTable(x=[], y=[], z=[]).group("x").group("y"),
+        DataTable(x=[], y=[]).group_by(),
+        DataTable(x=[]).group_by().group_by(),
+        DataTable(x=[], y=[], z=[]).group_by("x"),
+        DataTable(x=[], y=[], z=[]).group_by("x", "y"),
+        DataTable(x=[], y=[], z=[]).group_by("x").group_by("y"),
     ],
 )
 def test_filter_rowless(expression, table):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -69,11 +69,11 @@ def test_single_numeric_argument_against_python(name, function):
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
-        DataTable(a=[]).group("a"),
-        DataTable(a=[], b=[]).group("a", "b"),
-        DataTable(a=[], b=[]).group("a").group("b"),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
+        DataTable(a=[]).group_by("a"),
+        DataTable(a=[], b=[]).group_by("a", "b"),
+        DataTable(a=[], b=[]).group_by("a").group_by("b"),
     ],
 )
 def test_zero_argument_functions_on_rowless_table_with_mutate(name, table):
@@ -89,18 +89,18 @@ def test_zero_argument_functions_on_rowless_table_with_mutate(name, table):
         # Polars chokes on empty list in groupby
         # https://github.com/pola-rs/polars/issues/3041
         xfail_param(DataTable()),
-        xfail_param(DataTable().group()),
-        xfail_param(DataTable().group().group()),
+        xfail_param(DataTable().group_by()),
+        xfail_param(DataTable().group_by().group_by()),
         xfail_param(DataTable(a=[])),
-        DataTable(a=[]).group("a"),
-        DataTable(a=[], b=[]).group("a", "b"),
-        DataTable(a=[], b=[]).group("a").group("b"),
+        DataTable(a=[]).group_by("a"),
+        DataTable(a=[], b=[]).group_by("a", "b"),
+        DataTable(a=[], b=[]).group_by("a").group_by("b"),
     ],
 )
 def test_zero_argument_functions_on_rowless_table_with_summarize(name, table):
     expected = table.mutate(x="1")
 
-    actual = table.group().summarize(x=f"{name}()")
+    actual = table.group_by().summarize(x=f"{name}()")
     assert actual == expected
 
 
@@ -113,11 +113,11 @@ def test_zero_argument_functions_on_rowless_table_with_summarize(name, table):
     "table",
     [
         DataTable(a=[]),
-        DataTable(a=[]).group(),
-        DataTable(a=[]).group().group(),
-        DataTable(a=[]).group("a"),
-        DataTable(a=[], b=[], c=[]).group("a", "b"),
-        DataTable(a=[], b=[], c=[]).group("a").group("b"),
+        DataTable(a=[]).group_by(),
+        DataTable(a=[]).group_by().group_by(),
+        DataTable(a=[]).group_by("a"),
+        DataTable(a=[], b=[], c=[]).group_by("a", "b"),
+        DataTable(a=[], b=[], c=[]).group_by("a").group_by("b"),
     ],
 )
 def test_one_argument_functions_on_rowless_table_with_mutate(name, table):
@@ -134,6 +134,6 @@ def test_quantile():
 
 def test_trapz():
     table = DataTable(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4])
-    actual = table.group("id").summarize(q="trapz(t, y)")
+    actual = table.group_by("id").summarize(q="trapz(t, y)")
     expected = DataTable(id=[0, 1], q=[2.0, 13.0])
     assert_table_equal(actual, expected, reltol=1e-8)

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -8,5 +8,5 @@ def test_gather():
         sex=["M", "F", "M", "F", "M", "F"],
         grades=["0", "0", "1", "1", "2", "2"],
         count=[8, 9, 9, 10, 6, 9],
-    ).group("grades")
+    ).group_by("grades")
     assert actual == expected

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -4,38 +4,38 @@ from tabeline import DataTable
 from tabeline.exceptions import GroupColumn
 
 
-def test_group():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group("x")
+def test_group_by():
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
     assert table.group_levels == (("x",),)
 
 
-def test_group_multiple_columns():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group("x", "y")
+def test_group_by_multiple_columns():
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x", "y")
     assert table.group_levels == (("x", "y"),)
 
 
-def test_group_multiple_levels():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group("x").group("y")
+def test_group_by_multiple_levels():
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x").group_by("y")
     assert table.group_levels == (("x",), ("y",))
 
 
-def test_group_same_column_twice():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group("x")
+def test_group_by_same_column_twice():
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
     with pytest.raises(GroupColumn):
-        _ = table.group("x")
+        _ = table.group_by("x")
 
 
-def test_group_cluster():
+def test_group_by_cluster():
     table = DataTable(x=[1, 0, 1, 0], y=[3, 1, 2, 4])
-    actual = table.group("x", order="cluster")
-    expected = DataTable(x=[1, 1, 0, 0], y=[3, 2, 1, 4]).group("x")
+    actual = table.group_by("x", order="cluster")
+    expected = DataTable(x=[1, 1, 0, 0], y=[3, 2, 1, 4]).group_by("x")
     assert actual == expected
 
 
-def test_group_sort():
+def test_group_by_sort():
     table = DataTable(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
-    actual = table.group("x", order="sort")
-    expected = DataTable(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 3.4, 2.1, 0.0], z=[2, 1, 4, 5, 3]).group(
+    actual = table.group_by("x", order="sort")
+    expected = DataTable(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 3.4, 2.1, 0.0], z=[2, 1, 4, 5, 3]).group_by(
         "x"
     )
     assert actual == expected

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -12,16 +12,16 @@ def test_mutate():
 
 
 def test_mutate_grouped():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group("x")
+    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
     actual = table.mutate(z="y + 1")
-    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[1, 1, 2]).group("x")
+    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_referencing_group():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group("x")
+    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
     actual = table.mutate(z="~x")
-    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[False, True, False]).group("x")
+    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[False, True, False]).group_by("x")
     assert actual == expected
 
 
@@ -33,16 +33,16 @@ def test_mutate_overwrite():
 
 
 def test_mutate_overwrite_grouped():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group("x")
+    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
     actual = table.mutate(y="y + 1")
-    expected = DataTable(x=[True, False, True], y=[1, 1, 2]).group("x")
+    expected = DataTable(x=[True, False, True], y=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_overwrite_referencing_group():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group("x")
+    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
     actual = table.mutate(y="~x")
-    expected = DataTable(x=[True, False, True], y=[False, True, False]).group("x")
+    expected = DataTable(x=[True, False, True], y=[False, True, False]).group_by("x")
     assert actual == expected
 
 
@@ -54,9 +54,9 @@ def test_mutate_reference_previous_mutator():
 
 
 def test_mutate_reference_previous_mutator_grouped():
-    table = DataTable(x=[0, 0, 1]).group("x")
+    table = DataTable(x=[0, 0, 1]).group_by("x")
     actual = table.mutate(y="max(x)", z="y+1")
-    expected = DataTable(x=[0, 0, 1], y=[0, 0, 1], z=[1, 1, 2]).group("x")
+    expected = DataTable(x=[0, 0, 1], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
@@ -68,7 +68,7 @@ def test_mutate_broadcast_scalar():
 
 
 def test_mutate_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group("x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group_by("x")
     with pytest.raises(GroupColumn):
         _ = table.mutate(x="x+1")
 
@@ -77,8 +77,8 @@ def test_mutate_group_column():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_mutate_empty(table):
@@ -90,8 +90,8 @@ def test_mutate_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        # DataTable.columnless(height=6).group(),
-        # DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_mutate_columnless(table):
@@ -112,11 +112,11 @@ def test_mutate_columnless(table):
     "table",
     [
         DataTable(w=[], x=[], y=[], z=[]),
-        DataTable(w=[], x=[], y=[], z=[]).group(),
-        DataTable(w=[], x=[], y=[], z=[]).group().group(),
-        DataTable(w=[], x=[], y=[], z=[]).group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("x", "y"),
-        DataTable(w=[], x=[], y=[], z=[]).group("x").group("y"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by(),
+        DataTable(w=[], x=[], y=[], z=[]).group_by().group_by(),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "y"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("x").group_by("y"),
     ],
 )
 def test_mutate_rowless(expression, table):

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -37,58 +37,58 @@ def test_rename_swap(swappers):
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_into_group(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
     actual = table.rename(**swappers)
-    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group("y")
+    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y")
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_within_group(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
     actual = table.rename(**swappers)
-    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group("y", "x")
+    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y", "x")
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_between_group_levels(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y")
     actual = table.rename(**swappers)
     expected = (
-        DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group("y").group("x")
+        DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y").group_by("x")
     )
     assert actual == expected
 
 
 def test_rename_earlier_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
     actual = table.rename(xx="x")
-    expected = DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("xx", "y")
+    expected = DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("xx", "y")
     assert actual == expected
 
 
 def test_rename_later_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
     actual = table.rename(yy="y")
-    expected = DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group("x", "yy")
+    expected = DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group_by("x", "yy")
     assert actual == expected
 
 
 def test_rename_earlier_group_level():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y")
     actual = table.rename(xx="x")
     expected = (
-        DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("xx").group("y")
+        DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("xx").group_by("y")
     )
     assert actual == expected
 
 
 def test_rename_later_group_level():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y")
     actual = table.rename(yy="y")
     expected = (
-        DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group("x").group("yy")
+        DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("yy")
     )
     assert actual == expected
 
@@ -99,11 +99,11 @@ def test_rename_later_group_level():
         DataTable(),
         DataTable(x=[0, 0, 1]),
         DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
-        DataTable().group(),
-        DataTable(x=[0, 0, 1]).group("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y"),
+        DataTable().group_by(),
+        DataTable(x=[0, 0, 1]).group_by("x"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y"),
     ],
 )
 def test_noop_rename(table: DataTable):
@@ -118,9 +118,9 @@ def test_noop_rename(table: DataTable):
     "table",
     [
         DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
+        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y"),
     ],
 )
 def test_rename_self(columns, table):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -85,11 +85,11 @@ def test_select_columns_grouped(
 ):
     table = DataTable(**{name: test_columns[name] for name in input_columns})
     for level in groups:
-        table = table.group(*level)
+        table = table.group_by(*level)
     actual = table.select(*selectors)
     expected = DataTable(**{name: test_columns[name] for name in expected_columns})
     for level in groups:
-        expected = expected.group(*level)
+        expected = expected.group_by(*level)
     assert actual == expected
 
 
@@ -104,8 +104,8 @@ def test_select_nonexistent_column():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_select_empty(table):
@@ -117,8 +117,8 @@ def test_select_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_select_columnless(table):

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -28,9 +28,9 @@ def test_slice_out_of_bounds():
 
 
 def test_slice_groups():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group("x")
+    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[2, 1, 2, 1], y=[6.7, 8.9, -1.1, 4.5]).group("x")
+    expected = DataTable(x=[2, 1, 2, 1], y=[6.7, 8.9, -1.1, 4.5]).group_by("x")
 
     actual = table.slice0([1, 2])
     assert actual == expected
@@ -52,9 +52,9 @@ def test_slice_one_index():
 
 
 def test_slice_groups_one_index():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group("x")
+    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[2, 1], y=[6.7, 8.9]).group("x")
+    expected = DataTable(x=[2, 1], y=[6.7, 8.9]).group_by("x")
 
     actual = table.slice0([1])
     assert actual == expected
@@ -70,14 +70,14 @@ def test_slice_groups_multiple_columns_one_index():
             y=["a", "a", "a", "a", "b", "b", "b", "b"],
             z=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5, 4.3, 7.7],
         )
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
     )
 
     expected = (
         DataTable(x=[2, 1, 1, 2], y=["a", "a", "b", "b"], z=[6.7, 8.9, 4.3, 7.7])
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
     )
 
     actual = table.slice0([1])
@@ -100,9 +100,9 @@ def test_slice_to_nothing():
 
 
 def test_slice_groups_to_nothing():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group("x")
+    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[], y=[]).group("x")
+    expected = DataTable(x=[], y=[]).group_by("x")
 
     actual = table.slice0([])
     assert actual == expected
@@ -118,11 +118,11 @@ def test_slice_multiple_groups_to_nothing():
             y=["a", "a", "a", "a", "b", "b", "b", "b"],
             z=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5, 4.3, 7.7],
         )
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
     )
 
-    expected = DataTable(x=[], y=[], z=[]).group("x").group("y")
+    expected = DataTable(x=[], y=[], z=[]).group_by("x").group_by("y")
 
     actual = table.slice0([])
     assert actual == expected
@@ -132,7 +132,7 @@ def test_slice_multiple_groups_to_nothing():
 
 
 def test_slice_only_one_out_of_bounds():
-    table = DataTable(x=[1, 2, 2, 1, 2], y=[3.5, 2.2, 6.7, 8.9, -1.1]).group("x")
+    table = DataTable(x=[1, 2, 2, 1, 2], y=[3.5, 2.2, 6.7, 8.9, -1.1]).group_by("x")
 
     # General Exception because who know what will come out of Polars
     with pytest.raises(Exception):
@@ -146,8 +146,8 @@ def test_slice_only_one_out_of_bounds():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_slice_empty(table):
@@ -162,8 +162,8 @@ def test_slice_empty(table):
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_slice_empty_out_of_bounds(table):
@@ -181,10 +181,10 @@ def test_slice_empty_out_of_bounds(table):
     ["table", "expected"],
     [
         [DataTable.columnless(height=6), DataTable.columnless(height=3)],
-        [DataTable.columnless(height=6).group(), DataTable.columnless(height=3).group()],
+        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=3).group_by()],
         [
-            DataTable.columnless(height=6).group().group(),
-            DataTable.columnless(height=3).group().group(),
+            DataTable.columnless(height=6).group_by().group_by(),
+            DataTable.columnless(height=3).group_by().group_by(),
         ],
     ],
 )
@@ -200,8 +200,8 @@ def test_slice_columnless(table, expected):
     "table",
     [
         DataTable.columnless(height=4),
-        DataTable.columnless(height=4).group(),
-        DataTable.columnless(height=4).group().group(),
+        DataTable.columnless(height=4).group_by(),
+        DataTable.columnless(height=4).group_by().group_by(),
     ],
 )
 def test_slice_columnless_out_of_bounds(table):
@@ -216,8 +216,8 @@ def test_slice_columnless_out_of_bounds(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group(),
-        DataTable(x=[]).group().group(),
+        DataTable(x=[], y=[]).group_by(),
+        DataTable(x=[]).group_by().group_by(),
     ],
 )
 def test_slice_rowless(table):
@@ -234,8 +234,8 @@ def test_slice_rowless(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group(),
-        DataTable(x=[]).group().group(),
+        DataTable(x=[], y=[]).group_by(),
+        DataTable(x=[]).group_by().group_by(),
     ],
 )
 def test_slice_rowless_out_of_bounds(table):

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -18,29 +18,29 @@ def test_sort_two():
 
 
 def test_sort_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group("x")
+    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by("x")
     actual = table.sort("y")
-    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 5, 2, 3, 0, 4]).group(
+    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 5, 2, 3, 0, 4]).group_by(
         "x"
     )
     assert actual == expected
 
 
 def test_sort_two_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group("x")
+    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by("x")
     actual = table.sort("y", "z")
-    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 0, 2, 3, 5, 4]).group(
+    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 0, 2, 3, 5, 4]).group_by(
         "x"
     )
     assert actual == expected
 
 
 def test_sort_grouped_two():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group(
+    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by(
         "x", "y"
     )
     actual = table.sort("z")
-    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[0, 4, 3, 2, 1, 5]).group(
+    expected = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[0, 4, 3, 2, 1, 5]).group_by(
         "x", "y"
     )
     assert actual == expected
@@ -50,8 +50,8 @@ def test_sort_grouped_two():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_sort_empty(table):
@@ -63,8 +63,8 @@ def test_sort_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_sort_columnless(table):
@@ -77,11 +77,11 @@ def test_sort_columnless(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[], z=[]).group(),
-        DataTable(x=[], y=[], z=[]).group().group(),
-        DataTable(x=[], y=[], z=[]).group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("w").group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("x", "w"),
+        DataTable(x=[], y=[], z=[]).group_by(),
+        DataTable(x=[], y=[], z=[]).group_by().group_by(),
+        DataTable(x=[], y=[], z=[]).group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "w"),
     ],
 )
 def test_sort_rowless(columns, table):

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -5,6 +5,6 @@ def test_spread():
     table = DataTable(
         grades=[0, 0, 1, 1, 2, 2], sex=["M", "F", "M", "F", "M", "F"], count=[8, 9, 9, 10, 6, 9]
     )
-    actual = table.group("sex").spread("grades", "count")
+    actual = table.group_by("sex").spread("grades", "count")
     expected = DataTable.from_dict({"sex": ["M", "F"], "0": [8, 9], "1": [9, 10], "2": [6, 9]})
     assert actual == expected

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -7,12 +7,12 @@ def test_str():
 
 
 def test_str_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
     _ = str(table)
 
 
 def test_str_multiple_level_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y")
     _ = str(table)
 
 
@@ -22,10 +22,10 @@ def test_repr():
 
 
 def test_repr_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x", "y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
     _ = str(table)
 
 
 def test_repr_multiple_level_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group("x").group("y")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x").group_by("y")
     _ = str(table)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -5,42 +5,42 @@ from tabeline import DataTable
 
 def test_summarize():
     table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group("x").summarize(size="n()", max_y="max(y)")
+    actual = table.group_by("x").summarize(size="n()", max_y="max(y)")
     expected = DataTable(x=[0, 1], size=[2, 2], max_y=[2, 4])
     assert actual == expected
 
 
 def test_summarize_back_reference():
     table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group("x").summarize(max_y="max(y)", inverted="-max_y")
+    actual = table.group_by("x").summarize(max_y="max(y)", inverted="-max_y")
     expected = DataTable(x=[0, 1], max_y=[2, 4], inverted=[-2, -4])
     assert actual == expected
 
 
 def test_summarize_original_and_back_reference():
     table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 5])
-    actual = table.group("x").summarize(max_y="max(y)", range="max_y-min(y)")
+    actual = table.group_by("x").summarize(max_y="max(y)", range="max_y-min(y)")
     expected = DataTable(x=[0, 1], max_y=[2, 5], range=[1, 2])
     assert actual == expected
 
 
 def test_literal_in_summarize():
     table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group("x").summarize(new="1")
+    actual = table.group_by("x").summarize(new="1")
     expected = DataTable(x=[0, 1], new=[1, 1])
     assert actual == expected
 
 
 def test_empty_summarize():
     table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group("x").summarize()
+    actual = table.group_by("x").summarize()
     expected = DataTable(x=[0, 1])
     assert actual == expected
 
 
 def test_empty_summarize_on_two_groups():
     table = DataTable(x=[0, 0, 1, 1, 0], y=[1, 2, 2, 2, 2], z=[1, 2, 3, 4, 5])
-    actual = table.group("x", "y").summarize()
+    actual = table.group_by("x", "y").summarize()
     expected = DataTable(x=[0, 0, 1], y=[1, 2, 2])
     assert actual == expected
 
@@ -48,8 +48,8 @@ def test_empty_summarize_on_two_groups():
 @pytest.mark.parametrize(
     "table",
     [
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_summarize_empty(table):
@@ -61,8 +61,8 @@ def test_summarize_empty(table):
 @pytest.mark.parametrize(
     "table",
     [
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_summarize_columnless(table):
@@ -81,6 +81,6 @@ def test_summarize_columnless(table):
 )
 def test_summarize_rowless(expressions):
     table = DataTable(w=[], x=[], y=[], z=[])
-    actual = table.group("x", "y").summarize(**expressions)
+    actual = table.group_by("x", "y").summarize(**expressions)
     expected = DataTable(x=[], y=[], a=[], b=[])
     assert actual == expected

--- a/tests/test_transmute.py
+++ b/tests/test_transmute.py
@@ -12,16 +12,16 @@ def test_transmute():
 
 
 def test_transmute_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group("y", "x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
     actual = table.transmute(zz="z + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[4, 3, 5]).group("y", "x")
+    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[4, 3, 5]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_referencing_group():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group("y", "x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
     actual = table.transmute(zz="x + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[1, 1, 2]).group("y", "x")
+    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[1, 1, 2]).group_by("y", "x")
     assert actual == expected
 
 
@@ -33,20 +33,20 @@ def test_transmute_overwrite():
 
 
 def test_transmute_overwrite_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group(
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
         "y", "x"
     )
     actual = table.transmute(z="z + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[4, 3, 5]).group("y", "x")
+    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[4, 3, 5]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_overwrite_referencing_group():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group(
+    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
         "y", "x"
     )
     actual = table.transmute(z="x + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[1, 1, 2]).group("y", "x")
+    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[1, 1, 2]).group_by("y", "x")
     assert actual == expected
 
 
@@ -58,9 +58,9 @@ def test_transmute_reference_previous_mutator():
 
 
 def test_transmute_reference_previous_mutator_grouped():
-    table = DataTable(x=[0, 0, 1], a=[2.3, 4.5, 6.7]).group("x")
+    table = DataTable(x=[0, 0, 1], a=[2.3, 4.5, 6.7]).group_by("x")
     actual = table.transmute(y="x + 1", z="2*y")
-    expected = DataTable(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4]).group("x")
+    expected = DataTable(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4]).group_by("x")
     assert actual == expected
 
 
@@ -72,7 +72,7 @@ def test_transmute_broadcast_scalar():
 
 
 def test_transmute_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group("x")
+    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group_by("x")
     with pytest.raises(GroupColumn):
         _ = table.transmute(x="x+1")
 
@@ -81,8 +81,8 @@ def test_transmute_group_column():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_mutate_empty(table):
@@ -94,8 +94,8 @@ def test_mutate_empty(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_mutate_columnless(table):
@@ -115,11 +115,11 @@ def test_mutate_columnless(table):
     "table",
     [
         DataTable(y=[], z=[]),
-        DataTable(y=[], z=[]).group(),
-        DataTable(y=[], z=[]).group().group(),
-        DataTable(x=[], y=[], z=[]).group("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("w", "x"),
-        DataTable(w=[], x=[], y=[], z=[]).group("w").group("x"),
+        DataTable(y=[], z=[]).group_by(),
+        DataTable(y=[], z=[]).group_by().group_by(),
+        DataTable(x=[], y=[], z=[]).group_by("x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("w", "x"),
+        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
     ],
 )
 def test_transmute_rowless(expression, table):

--- a/tests/test_ungroup.py
+++ b/tests/test_ungroup.py
@@ -5,21 +5,21 @@ from tabeline.exceptions import NoGroups
 
 
 def test_ungroup():
-    actual = DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x").group("y").ungroup()
-    expected = DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x")
+    actual = DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup()
+    expected = DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x")
     assert actual == expected
 
 
 @pytest.mark.parametrize(
     "table",
     [
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group().ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x", "y").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group().group().ungroup().ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by().ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by().group_by().ungroup().ungroup(),
         DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
-        .group("x")
-        .group("y")
+        .group_by("x")
+        .group_by("y")
         .ungroup()
         .ungroup(),
     ],
@@ -31,11 +31,11 @@ def test_ungroup_completely(table):
 @pytest.mark.parametrize(
     "table",
     [
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x").group("y").ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup(),
         DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
-        .group("x")
-        .group()
-        .group("y")
+        .group_by("x")
+        .group_by()
+        .group_by("y")
         .ungroup()
         .ungroup(),
     ],
@@ -48,11 +48,11 @@ def test_ungroup_to_one_level(table):
     "table",
     [
         DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group("x", "y").ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
+        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
         DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
-        .group("y")
-        .group("x")
+        .group_by("y")
+        .group_by("x")
         .ungroup()
         .ungroup(),
     ],

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -11,9 +11,9 @@ def test_unique():
 
 
 def test_unique_grouped():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group("x")
+    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
     actual = table.unique()
-    expected = DataTable(x=[0, 0, 1], y=[1, 2, 3]).group("x")
+    expected = DataTable(x=[0, 0, 1], y=[1, 2, 3]).group_by("x")
     assert actual == expected
 
 
@@ -21,8 +21,8 @@ def test_unique_grouped():
     "table",
     [
         DataTable(),
-        DataTable().group(),
-        DataTable().group().group(),
+        DataTable().group_by(),
+        DataTable().group_by().group_by(),
     ],
 )
 def test_unique_empty(table):
@@ -34,8 +34,8 @@ def test_unique_empty(table):
     "table",
     [
         DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group(),
-        DataTable(x=[], y=[]).group().group(),
+        DataTable(x=[], y=[]).group_by(),
+        DataTable(x=[], y=[]).group_by().group_by(),
     ],
 )
 def test_unique_rowless(table):
@@ -47,8 +47,8 @@ def test_unique_rowless(table):
     "table",
     [
         DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group(),
-        DataTable.columnless(height=6).group().group(),
+        DataTable.columnless(height=6).group_by(),
+        DataTable.columnless(height=6).group_by().group_by(),
     ],
 )
 def test_unique_columnless(table):


### PR DESCRIPTION
By renaming the `group` verb to `group_by`, Tabeline is brought closer to dplyr, polars, pandas, and basically every other data table library. I always thought that it was weird that the group verb was the only one that included a preposition. We don't write `sort_by`, `filter_with`, or `mutate_according_to`, but we do write `group_by` for some reason. That being said, Tabeline has no chance of turning that ship, so we might as well go with what people are familiar with.