### PR TITLE
Rename DataTable to DataFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tabeline
 
-Tabeline is a data table and data grammar library. You write the expressions in strings and supply them to methods on the `DataTable` class. The  strings are parsed by Parsita and converted into Polars for execution.
+Tabeline is a data frame and data grammar library. You write the expressions in strings and supply them to methods on the `DataFrame` class. The  strings are parsed by Parsita and converted into Polars for execution.
 
 Tabeline draws inspiration from dplyr, the data grammar of R's tidyverse, especially for its methods names. The `filter`, `mutate`, `group_by`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipes, like is standard in R. 
 
@@ -19,20 +19,20 @@ pip install tabeline
 ## Motivating example
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-# Construct a table using clean syntax
+# Construct a data frame using clean syntax
 # from_csv, from_pandas, and from_polars are also available 
-table = DataTable(
+df = DataFrame(
     id=[0, 0, 0, 0, 1, 1, 1, 1, 1],
     t=[0, 6, 12, 24, 0, 6, 12, 24, 48],
     y=[0, 2, 3, 1, 0, 4, 3, 2, 1],
 )
 
 # Use data grammar methods and string expressions to define
-# transformed data tables
+# transformed data frames
 analysis = (
-    table
+    df
     .filter("t <= 24")
     .group_by("id")
     .summarize(auc="trapz(t, y)")

--- a/docs/creation.md
+++ b/docs/creation.md
@@ -1,18 +1,18 @@
-# Creating a table
+# Creating a data frame
 
-The central class of Tabeline is `tabeline.DataTable`. There is little to do with Tabeline other than constructing a `DataTable` and invoking methods on it to get a different `DataTable`.
+The central class of Tabeline is `tabeline.DataFrame`. There is little to do with Tabeline other than constructing a `DataFrame` and invoking methods on it to get a different `DataFrame`.
 
-To create a `DataTable`, you can either use the constructor or several static methods on the class.
+To create a `DataFrame`, you can either use the constructor or several static methods on the class.
 
 
-## `DataTable`
+## `DataFrame`
 
-The constructor for `DataTable` takes an arbitrary number of named arguments. The name of each argument creates a column with the same name. The value of each named argument must be a list, which becomes the values under that column. Naturally, all provided lists must have the same length.
+The constructor for `DataFrame` takes an arbitrary number of named arguments. The name of each argument creates a column with the same name. The value of each named argument must be a list, which becomes the values under that column. Naturally, all provided lists must have the same length.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     name=["A New Hope", "The Empire Strikes Back", "Return of the Jedi"],
     episode=[4, 5, 6],
     release_year=[1977, 1980, 1983],
@@ -24,49 +24,49 @@ table = DataTable(
     If you poke around in the code, you may notice that the contructor also takes positional arguments. Those are part of the private constructor; don't use them.
 
 
-## `DataTable.read_csv`
+## `DataFrame.read_csv`
 
-Reads a table from a CSV file.
+Reads a data frame from a CSV file.
 
 ```python
 from pathlib import Path
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable.read_csv(Path("star_wars.csv"))
+df = DataFrame.read_csv(Path("star_wars.csv"))
 ```
 
 
-## `DataTable.from_pandas`
+## `DataFrame.from_pandas`
 
-Create a `tabeline.DataTable` from a `pandas.DataFrame`. This ignores the index. Use `df.reset_index()` on the Pandas `DataFrame` to copy the index to columns first.
+Create a `tabeline.DataFrame` from a `pandas.DataFrame`. This ignores the index. Use `df.reset_index()` on the Pandas `DataFrame` to copy the index to columns first.
 
 ```python
-from polars import DataFrame
-from tabeline import DataTable
+import pandas as pd
+from tabeline import DataFrame
 
-df = DataFrame(dict(
+pandas_df = pd.DataFrame(dict(
     name=["A New Hope", "The Empire Strikes Back", "Return of the Jedi"],
     episode=[4, 5, 6],
     release_year=[1977, 1980, 1983],
 ))
 
-table = DataTable.from_pandas(df)
+df = DataFrame.from_pandas(pandas_df)
 ```
 
 
-## `DataTable.from_polars`
+## `DataFrame.from_polars`
 
-Create a `tabeline.DataTable` from a `polars.DataFrame`. Because Tabeline uses Polars internally, this is a simple wrapper.
+Create a `tabeline.DataFrame` from a `polars.DataFrame`. Because Tabeline uses Polars internally, this is a simple wrapper.
 
 ```python
-from polars import DataFrame
-from tabeline import DataTable
+import polars as pl
+from tabeline import DataFrame
 
-df = DataFrame(dict(
+polars_df = pl.DataFrame(dict(
     name=["A New Hope", "The Empire Strikes Back", "Return of the Jedi"],
     episode=[4, 5, 6],
     release_year=[1977, 1980, 1983],
 ))
 
-table = DataTable.from_polars(df)
+df = DataFrame.from_polars(polars_df)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Tabeline
 
-Tabeline is a data table and data grammar library. You write the expressions in strings and supply them to methods on the `DataTable` class, like `table.filter("t <= 24")`. The  strings are parsed by Parsita and converted into Polars for execution.
+Tabeline is a data frame and data grammar library. You write the expressions in strings and supply them to methods on the `DataFrame` class, like `df.filter("t <= 24")`. The  strings are parsed by Parsita and converted into Polars for execution.
 
 Tabeline draws inspiration from [dplyr](https://dplyr.tidyverse.org/), the data grammar of R's tidyverse. The `filter`, `mutate`, `group_by`, and `summarize` methods should all feel familiar. But Tabeline is as proper a Python library as can be, using methods instead of pipe operators. 
 
@@ -17,20 +17,20 @@ pip install tabeline
 ## Motivating example
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-# Construct a table using clean syntax
+# Construct a data frame using clean syntax
 # from_csv, from_pandas, and from_polars are also available 
-table = DataTable(
+df = DataFrame(
     id=[0, 0, 0, 0, 1, 1, 1, 1, 1],
     t=[0, 6, 12, 24, 0, 6, 12, 24, 48],
     y=[0, 2, 3, 1, 0, 4, 3, 2, 1],
 )
 
 # Use data grammar methods and string expressions to define
-# transformed data tables
+# transformed data frames
 analysis = (
-    table
+    df
     .filter("t <= 24")
     .group_by("id")
     .summarize(auc="trapz(t, y)")
@@ -51,14 +51,14 @@ print(analysis)
 
 ## Data grammar
 
-A data grammar is a particular style of data table library popularized by Hadley Wickham via the [dplyr](https://dplyr.tidyverse.org/) package in R. In a library written as a data grammar, the data table object has a relatively small number of methods. The parameters of most of these methods are columns names or expressions of column names. The return value of most of these methods is a new data table. These methods that transform a data table into another data table by taking simple inputs are called the "verbs" of the data grammar. Each verb does a single simple transformation. By always returning a new data table, the verbs can be cleanly combined via method chaining. The `filter` and `summarize` methods in the above example are two such verbs.
+A data grammar is a particular style of data frame library popularized by Hadley Wickham via the [dplyr](https://dplyr.tidyverse.org/) package in R. In a library written as a data grammar, the data frame object has a relatively small number of methods. The parameters of most of these methods are columns names or expressions of column names. The return value of most of these methods is a new data frame. These methods that transform a data frame into another data frame by taking simple inputs are called the "verbs" of the data grammar. Each verb does a single simple transformation. By always returning a new data frame, the verbs can be cleanly combined via method chaining. The `filter` and `summarize` methods in the above example are two such verbs.
 
-A user who wants to do an analysis of a data table, however basic, is unlikely to find a single function that does exactly what he wants. This is by design. It is not feasible to make a data table library that has a function for every kind of analysis someone would want. Tabeline expects the user to learn the data grammar so that he can split the analysis into steps than can be performed by verbs.
+A user who wants to do an analysis of a data frame, however basic, is unlikely to find a single function that does exactly what he wants. This is by design. It is not feasible to make a data frame library that has a function for every kind of analysis someone would want. Tabeline expects the user to learn the data grammar so that he can split the analysis into steps than can be performed by verbs.
 
 ### Expressions
 
-Tabeline uses strings to encapsulate expressions. The `"t <= 24"` and `"trapz(t, y)"` strings in above example are two such expressions. These strings are parsed and executed. The reason for using strings is that there is no cleaner way to write expressions in Python that need to be evaluated in a different context, namely in the context of the data table.
+Tabeline uses strings to encapsulate expressions. The `"t <= 24"` and `"trapz(t, y)"` strings in above example are two such expressions. These strings are parsed and executed. The reason for using strings is that there is no cleaner way to write expressions in Python that need to be evaluated in a different context, namely in the context of the data frame.
 
-In R, all functions are effectively macros that can capture any expressions they are given to be executed at a later time. For example, `df %>% filter(t <= 24)` in dplyr evaluates using the `t` column in the table, not the `t` variable in the outer scope, if it is even defined.
+In R, all functions are effectively macros that can capture any expressions they are given to be executed at a later time. For example, `df %>% filter(t <= 24)` in dplyr evaluates using the `t` column in the data frame, not the `t` variable in the outer scope, if it is even defined.
 
-In Python, the closest thing is the `lambda`. It would be trivial to make an interface that single argument function, which would be passed the data table or some modified version of the data table. For example, `table.filter(lambda df: df.t <= 24)`. However, anonymous functions have particularly bad syntax in Python, and they work particularly badly in the face of multiple arguments (like would be needed for `mutate`). The `lambda` operator has lower precedence than the commas that separate arguments, so most lambdas need to be surrounded by parentheses.
+In Python, the closest thing is the `lambda`. It would be trivial to make an interface that single argument function, which would be passed to the data frame or some modified version of the data frame. For example, `df.filter(lambda df: df.t <= 24)`. However, anonymous functions have particularly bad syntax in Python, and they work particularly badly in the face of multiple arguments (like would be needed for `mutate`). The `lambda` operator has lower precedence than the commas that separate arguments, so most lambdas need to be surrounded by parentheses.

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -4,16 +4,16 @@ This is an index of the main functionality available in Tabeline. Each construct
 
 ## Creation
 
-These are the ways to create a `DataTable` from something that is not already a `DataTable`
+These are the ways to create a `DataFrame` from something that is not already a `DataFrame`
 
-* [`DataTable(**columns)`](creation.md#datatable): Construct table directly from columns
-* [`DataTable.read_csv(filename)`](creation.md#datatableread_csv): Read table from CSV file
-* [`DataTable.from_pandas(df)`](creation.md#datatablefrom_pandas): Convert from Pandas `DataFrame`
-* [`DataTable.from_polars(df)`](creation.md#datatablefrom_polars): Convert from Polars `DataFrame`
+* [`DataFrame(**columns)`](creation.md#dataframe): Construct data frame directly from columns
+* [`DataFrame.read_csv(filename)`](creation.md#dataframeread_csv): Read data frame from CSV file
+* [`DataFrame.from_pandas(df)`](creation.md#dataframefrom_pandas): Convert from Pandas `DataFrame`
+* [`DataFrame.from_polars(df)`](creation.md#dataframefrom_polars): Convert from Polars `DataFrame`
 
 ## Verbs
 
-Each verb is a method of `DataTable`.
+Each verb is a method of `DataFrame`.
 
 ### Column reorganization
 
@@ -31,7 +31,7 @@ Each verb is a method of `DataTable`.
 
 ### Row reordering
 
-* [`sort`](verbs/sort.md#sort): Sort table according to given columns
+* [`sort`](verbs/sort.md#sort): Sort data frame according to given columns
 * [`cluster`](verbs/sort.md#cluster): Bring rows together with same values under given columns
 
 ### Column mutation
@@ -55,9 +55,9 @@ Each verb is a method of `DataTable`.
 
 ### Joining
 
-* [`inner_join`](verbs/join.md#inner_join): Merge tables, dropping unmatched
-* [`outer_join`](verbs/join.md#outer_join): Merge tables, adding nulls for unmatched
-* [`left_join`](verbs/join.md#left_join): Merge tables, adding nulls for unmatched on the left table
+* [`inner_join`](verbs/join.md#inner_join): Merge data frames, dropping unmatched
+* [`outer_join`](verbs/join.md#outer_join): Merge data frames, adding nulls for unmatched
+* [`left_join`](verbs/join.md#left_join): Merge data frames, adding nulls for unmatched on the left data frame
 
 ## Functions
 

--- a/docs/verbs/filter.md
+++ b/docs/verbs/filter.md
@@ -4,17 +4,17 @@ The `filter`, `slice0`, `slice1`, `distinct`, and `unique` verbs change which ro
 
 ## `filter`
 
-Keep the rows for which a given predicate evaluates to true. `filter` takes a single expression, which in the context of the table, must evaluate to a boolean column. All rows with a corresponding false value are dropped.
+Keep the rows for which a given predicate evaluates to true. `filter` takes a single expression, which in the context of the data frame, must evaluate to a boolean column. All rows with a corresponding false value are dropped.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     name=["Alice", "Bob", "Carole", "Mallory"],
     age=[28, 55, 55, 18],
 )
 
-table.filter("age == max(age)")
+df.filter("age == max(age)")
 # shape: (2, 2)
 # ┌────────┬─────┐
 # │ name   ┆ age │
@@ -32,14 +32,14 @@ table.filter("age == max(age)")
 Keep only the rows whose 0-based index is listed, and in the order listed.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     id=[1, 2, 3, 4],
     character=["a", "b", "c", "d"],
 )
 
-table.slice0([2, 1])
+df.slice0([2, 1])
 # ┌─────┬───────────┐
 # │ id  ┆ character │
 # │ --- ┆ ---       │
@@ -56,14 +56,14 @@ table.slice0([2, 1])
 Keep only the rows whose 1-based index is listed, and in the order listed. This is identical to `slice0` except for the interpretation of the index.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     id=[1, 2, 3, 4],
     character=["a", "b", "c", "d"],
 )
 
-table.slice1([2, 1])
+df.slice1([2, 1])
 # shape: (2, 2)
 # ┌─────┬───────────┐
 # │ id  ┆ character │

--- a/docs/verbs/group_by.md
+++ b/docs/verbs/group_by.md
@@ -1,22 +1,22 @@
 # Grouping
 
-`group_by` is not so much a verb as it is a preposition. `group_by` does not change the contents or orders of any rows or columns, but it changes the context of subsequent verbs. All rows which have the same values in all group_by columns are members of the same subtable. Subsequent verbs act as if they are applied each subtable individually. So in `filter` or `mutate`, an expression containing `max` or `mean` will apply only to the rows in each subtable. 
+`group_by` is not so much a verb as it is a preposition. `group_by` does not change the contents or orders of any rows or columns, but it changes the context of subsequent verbs. All rows which have the same values in all group_by columns are members of the same subframe. Subsequent verbs act as if they are applied each subframe individually. So in `filter` or `mutate`, an expression containing `max` or `mean` will apply only to the rows in each subframe. 
 
-Tabeline is different from all popular data grammar libraries in how it handles groups. An instance of `DataTable` has group levels. Each invocation of `group_by` adds one group level, which can contain any number of columns names by which to group. The flattened list of group names from all levels can be accessed via the `group_names` property.
+Tabeline is different from all popular data grammar libraries in how it handles groups. An instance of `DataFrame` has group levels. Each invocation of `group_by` adds one group level, which can contain any number of columns names by which to group. The flattened list of group names from all levels can be accessed via the `group_names` property.
 
 ## `group_by`
 
 Add a set of column names as a new group level. The column names must exist, and they must not be previously grouped.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
-    id = ["a", "a", "b", "b"],
-    x = [1, 2, 3, 4],
+df = DataFrame(
+    id=["a", "a", "b", "b"],
+    x=[1, 2, 3, 4],
 )
 
-table.group_by("id").mutate(mean="mean(x)")
+df.group_by("id").mutate(mean="mean(x)")
 # group levels: [id]
 # shape: (4, 3)
 # ┌─────┬─────┬──────┐
@@ -41,14 +41,14 @@ Drop the last group level.
 The existence of group levels causes this to behave differently from dplyr. This does not remove all group names, only those present in the last group level.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
-    id = ["a", "a", "b", "b"],
-    x = [1, 2, 3, 4],
+df = DataFrame(
+    id=["a", "a", "b", "b"],
+    x=[1, 2, 3, 4],
 )
 
-table.group_by("id").mutate(mean="mean(x)")
+df.group_by("id").mutate(mean="mean(x)")
 # shape: (4, 3)
 # ┌─────┬─────┬──────┐
 # │ id  ┆ x   ┆ mean │

--- a/docs/verbs/join.md
+++ b/docs/verbs/join.md
@@ -7,12 +7,12 @@ The `inner_join`, `outer_join`,  and `left_join` verbs perform the classic table
 This method performs the classic inner join operation. Rows on either side that are missing a corresponding row on the other side are dropped. Rows on either side that have multiple matches on the other side are duplicated.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-table1.inner_join(table2)
+df1.inner_join(df2)
 # shape: (4, 3)
 # ┌─────┬─────┬─────┐
 # │ x   ┆ y   ┆ z   │
@@ -34,12 +34,12 @@ table1.inner_join(table2)
 This method performs the classic outer join (or full join) operation. Rows on either side that are missing a corresponding row on the other side are kept, filling the other side with nulls. Rows on either side that have multiple matches on the other side are duplicated.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-table1.outer_join(table2)
+df1.outer_join(df2)
 # shape: (6, 3)
 # ┌─────┬──────┬──────┐
 # │ x   ┆ y    ┆ z    │
@@ -65,12 +65,12 @@ table1.outer_join(table2)
 This method performs the classic left join operation. Rows on the left side that are missing a corresponding row on the right side are kept, filling the right side with nulls. Rows on the right side that are missing a corresponding row on the left side are dropped. Rows on either side that have multiple matches on the other side are duplicated.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-table1.left_join(table2)
+df1.left_join(df2)
 # shape: (5, 3)
 # ┌─────┬─────┬──────┐
 # │ x   ┆ y   ┆ z    │

--- a/docs/verbs/mutate.md
+++ b/docs/verbs/mutate.md
@@ -8,15 +8,15 @@ The `mutate` and `transmute` verbs create new columns based on expressions of ex
 Create new columns or redefine existing columns. This takes an arbitrary number of named arguments. The name of each argument is the name of a column. The value of the argument is an expression that provides a definition for that column. If the column name already exists, that column will be replaced by the evaluation of the new definition. If the column name does not already exist, the new column will be appended to the existing columns.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
-    name = ["wide", "tall", "square"],
-    width = [5, 2, 3],
-    height = [1, 4, 3],
+df = DataFrame(
+    name=["wide", "tall", "square"],
+    width=[5, 2, 3],
+    height=[1, 4, 3],
 )
 
-table.mutate(area="width * height")
+df.mutate(area="width * height")
 # ┌────────┬───────┬────────┬──────┐
 # │ name   ┆ width ┆ height ┆ area │
 # │ ---    ┆ ---   ┆ ---    ┆ ---  │
@@ -35,15 +35,15 @@ table.mutate(area="width * height")
 Just like mutate except the existing columns are not kept. This is identical to `mutate` followed by `select` on the newly defined columns.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
-    name = ["wide", "tall", "square"],
-    width = [5, 2, 3],
-    height = [1, 4, 3],
+df = DataFrame(
+    name=["wide", "tall", "square"],
+    width=[5, 2, 3],
+    height=[1, 4, 3],
 )
 
-table.transmute(name="name", area="width * height")
+df.transmute(name="name", area="width * height")
 # shape: (3, 2)
 # ┌────────┬──────┐
 # │ name   ┆ area │

--- a/docs/verbs/select.md
+++ b/docs/verbs/select.md
@@ -1,22 +1,22 @@
 # Column dropping and reordering
 
-The `select`, `deselect`, and `rename` verbs change which columns are present in the table, their order, and what names they have. The content of the columns is unchanged.
+The `select`, `deselect`, and `rename` verbs change which columns are present in the data frame, their order, and what names they have. The content of the columns is unchanged.
 
 ## `select`
 
 Keep only the columns whose names are listed, in the order they are listed.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     study=[1, 2],
     location=["USA", "USA"],
     cost=[3254, 11843],
     success=[True, False],
 )
 
-table.select("study", "success", "cost")
+df.select("study", "success", "cost")
 # shape: (2, 3)
 # ┌───────┬─────────┬───────┐
 # │ study ┆ success ┆ cost  │
@@ -34,16 +34,16 @@ table.select("study", "success", "cost")
 Drop the columns whose names are listed.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     study=[1, 2],
     location=["USA", "USA"],
     cost=[3254, 11843],
     success=[True, False],
 )
 
-table.deselect("location")
+df.deselect("location")
 # shape: (2, 3)
 # ┌───────┬───────┬─────────┐
 # │ study ┆ cost  ┆ success │
@@ -60,19 +60,19 @@ table.deselect("location")
 
 Change the name of some columns, keeping their original order unchanged. This takes named arguments, where the key is the new name and the value is the old name. In this, Tabeline is like [dyplr rename](https://dplyr.tidyverse.org/reference/rename.html) rather than [Polars rename](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.DataFrame.rename.html), which flips the order of the new and old names.
 
-The renaming happens simultaneously, allowing column names to be swapped. 
+The renaming happens simultaneously, allowing column names to be swapped.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     name=[1, 2],
     full_name=["Alice", "Bob"],
     age=[27, 55],
     authorized=[True, True],
 )
 
-table.rename(name="full_name", id="name")
+df.rename(name="full_name", id="name")
 # shape: (2, 4)
 # ┌─────┬───────┬─────┬────────────┐
 # │ id  ┆ name  ┆ age ┆ authorized │

--- a/docs/verbs/sort.md
+++ b/docs/verbs/sort.md
@@ -4,18 +4,18 @@ The `sort` and `cluster` verbs change the order of rows. The individual rows are
 
 ## `sort`
 
-Sort rows according to the given column names. The table is sorted by the first column name using subsequent columns to break any ties.
+Sort rows according to the given column names. The data frame is sorted by the first column name using subsequent columns to break any ties.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     patient_id=[2, 1, 2, 1, 2, 1],
     t=[0.0, 0.0, 6.0, 6.0, 24.0, 24.0],
     measurement=[6.0, 5.5, 4.2, 4.0, 3.1, 3.0],
 )
 
-table.sort("patient_id", "t")
+df.sort("patient_id", "t")
 # ┌────────────┬──────┬─────────────┐
 # │ patient_id ┆ t    ┆ measurement │
 # │ ---        ┆ ---  ┆ ---         │
@@ -41,15 +41,15 @@ table.sort("patient_id", "t")
 Bring together all the rows with the same value under the given columns. A side effect of `sort` is that all rows with the same key value under some given columns are brought together. If you want this clustering, without the sorting, `cluster` will bring all the rows with a given key together, but retain the order of first instance of that key.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     patient_id=[2, 1, 2, 1, 2, 1],
     t=[0.0, 0.0, 6.0, 6.0, 24.0, 24.0],
     measurement=[6.0, 5.5, 4.2, 4.0, 3.1, 3.0],
 )
 
-table.cluster("patient_id")
+df.cluster("patient_id")
 shape: (6, 3)
 # ┌────────────┬──────┬─────────────┐
 # │ patient_id ┆ t    ┆ measurement │

--- a/docs/verbs/spread.md
+++ b/docs/verbs/spread.md
@@ -1,21 +1,21 @@
 # Pivoting
 
-The `spread` and `gather` verbs reshape a table between long format and wide format of data representation.
+The `spread` and `gather` verbs reshape a data frame between long format and wide format of data representation.
 
 ## `spread`
 
-Turn a long table into a wide table. This operation takes the names of two columns, a key column and a value column. Every value in the key column becomes a column name and every value in the value column becomes a value under its respective column.
+Turn a long data frame into a wide data frame. This operation takes the names of two columns, a key column and a value column. Every value in the key column becomes a column name and every value in the value column becomes a value under its respective column.
 
-`spread` is a reduction verb. As such, it drops the last group level, and it cannot be applied to tables with no group levels.
+`spread` is a reduction verb. As such, it drops the last group level, and it cannot be applied to data frames with no group levels.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
+df = DataFrame(
     grades=[0, 0, 1, 1, 2, 2], sex=["M", "F", "M", "F", "M", "F"], count=[8, 9, 9, 10, 6, 9]
 )
 
-table.group_by("sex").spread("grades", "count")
+df.group_by("sex").spread("grades", "count")
 # shape: (2, 4)
 # ┌─────┬─────┬─────┬─────┐
 # │ sex ┆ 0   ┆ 1   ┆ 2   │
@@ -30,21 +30,21 @@ table.group_by("sex").spread("grades", "count")
 
 ## `gather`
 
-Turn a wide table into a long table. This operation takes the name of a key column that not exist, the name of a value column that does not exist, and an arbitrary number of existing column names. Each value under the existing columns is converted to a value under the new value column, with the name of the column put next to it under the key column.
+Turn a wide data frame into a long data frame. This operation takes the name of a key column that not exist, the name of a value column that does not exist, and an arbitrary number of existing column names. Each value under the existing columns is converted to a value under the new value column, with the name of the column put next to it under the key column.
 
 `gather` adds one group level containing the key column name.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable.from_dict({
+df = DataFrame.from_dict({
     "sex": ["M", "F"],
     "0": [8, 9],
     "1": [9, 10],
     "2": [6, 9]},
 )
 
-table.gather("grades", "count", "0", "1", "2")
+df.gather("grades", "count", "0", "1", "2")
 # group levels: [grades]
 # shape: (6, 3)
 # ┌─────┬────────┬───────┐

--- a/docs/verbs/summarize.md
+++ b/docs/verbs/summarize.md
@@ -2,17 +2,17 @@
 
 ## `summarize`
 
-Reduce each subtable to a single row. This operation can only be applied to a table with at least one group level. The result has one column for each group column name and one column for each named argument. The name of the argument becomes the column name and the value of the argument must be an expression that evaluates to a scalar. That scalar will be the value of the cell for each summarized subtable. The last group level is dropped.
+Reduce each subframe to a single row. This operation can only be applied to a data frame with at least one group level. The result has one column for each group column name and one column for each named argument. The name of the argument becomes the column name and the value of the argument must be an expression that evaluates to a scalar. That scalar will be the value of the cell for each summarized subframe. The last group level is dropped.
 
 ```python
-from tabeline import DataTable
+from tabeline import DataFrame
 
-table = DataTable(
-    id = ["a", "a", "b", "b"],
-    x = [1, 2, 3, 4],
+df = DataFrame(
+    id=["a", "a", "b", "b"],
+    x=[1, 2, 3, 4],
 )
 
-table.group_by("id").summarize(x="mean(x)")
+df.group_by("id").summarize(x="mean(x)")
 # shape: (2, 2)
 # ┌─────┬─────┐
 # │ id  ┆ x   │

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Tabeline
-site_description: Data table and data grammar library for Python
+site_description: Data frame and data grammar library for Python
 site_author: David Hagen
 
 repo_name: drhagen/tabeline
@@ -50,7 +50,7 @@ extra:
 nav:
   - Home: index.md
   - Index: summary.md
-  - Table creation: creation.md
+  - Data frame creation: creation.md
   - Verbs:
     - Reorganizing: verbs/select.md
     - Filtering: verbs/filter.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "tabeline"
 version = "0.1.1"
-description = "A data table and data grammar library"
+description = "A data frame and data grammar library"
 authors = ["David Hagen <david@drhagen.com>"]
 license = "MIT"
 readme = "README.md"
 documentation = "https://tabeline.drhagen.com"
 repository = "https://github.com/drhagen/tabeline"
-keywords = ["data", "table", "grammar", "dplyr"]
+keywords = ["dataframe", "datatable", "datagrammar", "dplyr"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",

--- a/src/tabeline/__init__.py
+++ b/src/tabeline/__init__.py
@@ -1,2 +1,4 @@
 from . import exceptions  # noqa: F401
-from ._data_table import DataTable  # noqa: F401
+from ._data_frame import DataFrame  # noqa: F401
+
+DataTable = DataFrame

--- a/src/tabeline/__init__.py
+++ b/src/tabeline/__init__.py
@@ -1,4 +1,4 @@
 from . import exceptions  # noqa: F401
-from ._data_frame import DataFrame  # noqa: F401
+from ._data_frame import DataFrame
 
 DataTable = DataFrame

--- a/src/tabeline/_data_frame.py
+++ b/src/tabeline/_data_frame.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-__all__ = ["DataTable"]
+__all__ = ["DataFrame"]
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union
 
 import polars as pl
 
-from ._dummy import dummy_name, dummy_table
+from ._dummy import dummy_frame, dummy_name
 from ._expression import substitute, to_polars
 from ._expression.ast import Expression
 from ._validation import assert_legal_columns, missing
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-class DataTable:
+class DataFrame:
     def __init__(
         self,
         polars_df: pl.DataFrame = missing,
@@ -50,11 +50,11 @@ class DataTable:
             else:
                 self.height = self._df.height  # With no height, height is taken from polars
         else:
-            raise TypeError("DataTable() takes 0 positional arguments but 1 was given")
+            raise TypeError("DataFrame() takes 0 positional arguments but 1 was given")
 
     @staticmethod
-    def columnless(*, height: int) -> DataTable:
-        return DataTable(pl.DataFrame({}), (), height)
+    def columnless(*, height: int) -> DataFrame:
+        return DataFrame(pl.DataFrame({}), (), height)
 
     @property
     def width(self) -> int:
@@ -73,17 +73,17 @@ class DataTable:
         return tuple(names for level in self.group_levels for names in level)
 
     @staticmethod
-    def from_dict(columns: dict[str, list[Any]], /) -> DataTable:
+    def from_dict(columns: dict[str, list[Any]], /) -> DataFrame:
         df = pl.DataFrame(columns)
-        return DataTable(df)
+        return DataFrame(df)
 
     @staticmethod
-    def from_pandas(df: pd.DataFrame) -> DataTable:
+    def from_pandas(df: pd.DataFrame) -> DataFrame:
         if df.shape[1] == 0:
-            # Polars does not understand columnless tables
-            return DataTable.columnless(height=df.shape[0])
+            # Polars does not understand columnless data frames
+            return DataFrame.columnless(height=df.shape[0])
 
-        return DataTable(pl.from_pandas(df))
+        return DataFrame(pl.from_pandas(df))
 
     def to_pandas(self) -> pd.DataFrame:
         import numpy as np
@@ -93,14 +93,14 @@ class DataTable:
             raise HasGroups()
 
         if self.width == 0:
-            # Polars does not understand columnless tables
+            # Polars does not understand columnless data frames
             return pd.DataFrame(np.empty((self.height, 0)))
 
         return self._df.to_pandas()
 
     @staticmethod
-    def from_polars(df: pl.DataFrame) -> DataTable:
-        return DataTable(df)
+    def from_polars(df: pl.DataFrame) -> DataFrame:
+        return DataFrame(df)
 
     def to_polars(self) -> pl.DataFrame:
         if len(self.group_levels) != 0:
@@ -109,9 +109,9 @@ class DataTable:
         return self._df
 
     @staticmethod
-    def read_csv(path: Path) -> DataTable:
+    def read_csv(path: Path) -> DataFrame:
         df = pl.read_csv(str(path))
-        return DataTable(df)
+        return DataFrame(df)
 
     def write_csv(self, path: Path) -> None:
         if len(self.group_levels) != 0:
@@ -119,19 +119,19 @@ class DataTable:
 
         self._df.write_csv(str(path))
 
-    def slice0(self, indexes: list[int], /) -> DataTable:
+    def slice0(self, indexes: list[int], /) -> DataFrame:
         # Negative indexes are not supported by Polars, so they are not
         # supported in Tabeline.
         if self.width == 0:
             for index in indexes:
                 if index >= self.height or index < 0:
                     raise IndexOutOfRange(index, self.height)
-            return DataTable(self._df, self.group_levels, len(indexes))
+            return DataFrame(self._df, self.group_levels, len(indexes))
         else:
             group_names = self.group_names
             if len(group_names) == 0:
                 # Polars chokes on empty groups
-                return DataTable(self._df.select(pl.all().take(indexes)), self.group_levels)
+                return DataFrame(self._df.select(pl.all().take(indexes)), self.group_levels)
             else:
                 # There is no easy way to slice by groups in Polars. Using
                 # `take` on a group causes the sliced columns to be a column of
@@ -146,7 +146,7 @@ class DataTable:
 
                 if len(indexes) == 0:
                     # Polars is not type stable when exploding no elements on a
-                    # grouped table, so just drop all rows.
+                    # grouped data frame, so just drop all rows.
                     # https://github.com/pola-rs/polars/issues/6723
                     new_df = self._df.select(pl.all().take(indexes))
                 elif len(indexes) == 1:
@@ -173,34 +173,34 @@ class DataTable:
                         .collect()
                     )
 
-                return DataTable(new_df, self.group_levels)
+                return DataFrame(new_df, self.group_levels)
 
-    def slice1(self, indexes: list[int], /) -> DataTable:
+    def slice1(self, indexes: list[int], /) -> DataFrame:
         return self.slice0([index - 1 for index in indexes])
 
-    def filter(self, predicate: str, /) -> DataTable:
+    def filter(self, predicate: str, /) -> DataFrame:
         expression = to_polars(Expression.parse(predicate).or_die())
 
         if self.width == 0:
-            # There is no way to evaluate an expression outside a datatable, so
-            # make a dummy table with the right number of rows.
+            # There is no way to evaluate an expression outside a data frame, so
+            # make a dummy data frame with the right number of rows.
             # eager=True needed because lazy expressions are not allowed in
             # the constructor
             # https://github.com/pola-rs/polars/issues/2983
-            height = dummy_table(self.height).filter(expression).height
-            return DataTable(pl.DataFrame({}), self.group_levels, height)
+            height = dummy_frame(self.height).filter(expression).height
+            return DataFrame(pl.DataFrame({}), self.group_levels, height)
         else:
             flat_groups = list(self.group_names)
             if len(flat_groups) > 0 and self.height > 0:
                 windowed_expression = expression.over(flat_groups)
             else:
                 # Polars chokes on an empty window
-                # Polars chokes on window over rowless table
+                # Polars chokes on window over rowless data frame
                 windowed_expression = expression
 
-            return DataTable(self._df.filter(windowed_expression), self.group_levels)
+            return DataFrame(self._df.filter(windowed_expression), self.group_levels)
 
-    def distinct(self, *columns: str) -> DataTable:
+    def distinct(self, *columns: str) -> DataFrame:
         assert_legal_columns(columns, self.column_names)
 
         # Polars chokes on duplicate columns
@@ -212,19 +212,19 @@ class DataTable:
                 # Polars chokes on an empty distinct subset
                 return self
             else:
-                return DataTable(self._df.head(1), self.group_levels, 1)
+                return DataFrame(self._df.head(1), self.group_levels, 1)
         else:
-            return DataTable(
+            return DataFrame(
                 self._df.unique(subset=all_columns, maintain_order=True), self.group_levels
             )
 
-    def unique(self) -> DataTable:
+    def unique(self) -> DataFrame:
         if self.width == 0:
-            return DataTable(pl.DataFrame({}), self.group_levels, min(1, self.height))
+            return DataFrame(pl.DataFrame({}), self.group_levels, min(1, self.height))
 
-        return DataTable(self._df.unique(maintain_order=True), self.group_levels)
+        return DataFrame(self._df.unique(maintain_order=True), self.group_levels)
 
-    def cluster(self, *columns: str) -> DataTable:
+    def cluster(self, *columns: str) -> DataFrame:
         assert_legal_columns(columns, self.column_names, self.group_names)
 
         flat_groups = self.group_names
@@ -237,7 +237,7 @@ class DataTable:
 
         if len(flat_groups) == 0:
             # Polars chokes on empty window columns
-            return DataTable(
+            return DataFrame(
                 self._df.lazy()
                 .with_columns(pl.arange(0, pl.count()).alias("_index"))
                 .with_columns(pl.min("_index").over(all_columns))
@@ -248,7 +248,7 @@ class DataTable:
                 self.height,
             )
         else:
-            return DataTable(
+            return DataFrame(
                 self._df.lazy()
                 .with_columns(pl.arange(0, pl.count()).alias("_index"))
                 .with_columns(pl.min("_index").over(all_columns))
@@ -259,22 +259,22 @@ class DataTable:
                 self.height,
             )
 
-    def sort(self, *columns: str) -> DataTable:
+    def sort(self, *columns: str) -> DataFrame:
         assert_legal_columns(columns, self.column_names, self.group_names)
 
         flat_groups = self.group_names
         if len(flat_groups) == 0 or self.height == 0:
             # Polars chokes on empty groups
             # Polars chokes on windowing over empty rows
-            return DataTable(self._df.sort(list(columns)), self.group_levels, self.height)
+            return DataFrame(self._df.sort(list(columns)), self.group_levels, self.height)
         else:
-            return DataTable(
+            return DataFrame(
                 self._df.select(pl.all().sort_by(list(columns)).over(list(flat_groups))),
                 self.group_levels,
                 self.height,
             )
 
-    def select(self, *columns: str) -> DataTable:
+    def select(self, *columns: str) -> DataFrame:
         assert_legal_columns(columns, self.column_names)
 
         # Group columns cannot be deselected. Prepend any group columns that
@@ -289,16 +289,16 @@ class DataTable:
             if column in group_set and column not in select_set
         )
 
-        return DataTable(
+        return DataFrame(
             self._df.select(unmentioned_groups + columns), self.group_levels, self.height
         )
 
-    def deselect(self, *columns: str) -> DataTable:
+    def deselect(self, *columns: str) -> DataFrame:
         assert_legal_columns(columns, self.column_names, self.group_names)
 
-        return DataTable(self._df.drop(list(columns)), self.group_levels, self.height)
+        return DataFrame(self._df.drop(list(columns)), self.group_levels, self.height)
 
-    def rename(self, **names: str) -> DataTable:
+    def rename(self, **names: str) -> DataFrame:
         # Renames are processed simultaneously. Overwriting an existing column
         # is not permitted with this operation. Temporary column names may not
         # be used; columns to be swapped should simply be swapped. Renaming a
@@ -329,16 +329,16 @@ class DataTable:
             for level in self.group_levels
         )
 
-        return DataTable(self._df.rename(rename_map), groups, self.height)
+        return DataFrame(self._df.rename(rename_map), groups, self.height)
 
-    def mutate(self, **mutators: str) -> DataTable:
+    def mutate(self, **mutators: str) -> DataFrame:
         group_set = set(self.group_names)
         for column in mutators.keys():
             if column in group_set:
                 raise GroupColumn(column)
 
         if self.width == 0:
-            df = dummy_table(self.height)
+            df = dummy_frame(self.height)
         else:
             df = self._df
 
@@ -363,45 +363,45 @@ class DataTable:
         if self.width == 0:
             polars_operation = polars_operation.drop(dummy_name)
 
-        return DataTable(polars_operation.collect(), self.group_levels, self.height)
+        return DataFrame(polars_operation.collect(), self.group_levels, self.height)
 
-    def transmute(self, **mutators: str) -> DataTable:
-        mutated_table = self.mutate(**mutators)
+    def transmute(self, **mutators: str) -> DataFrame:
+        mutated_df = self.mutate(**mutators)
 
         # Keep group columns and explicitly mentioned columns, all in the order
         # of group columns followed by explicit columns
-        return mutated_table.select(*self.group_names, *mutators.keys())
+        return mutated_df.select(*self.group_names, *mutators.keys())
 
     def group_by(
         self, *columns: str, order: Literal["original", "cluster", "sort"] = "original"
-    ) -> DataTable:
+    ) -> DataFrame:
         assert_legal_columns(columns, self.column_names, self.group_names)
 
         if order == "original":
-            ordered_table = self
+            ordered_df = self
         elif order == "cluster":
-            ordered_table = self.cluster(*columns)
+            ordered_df = self.cluster(*columns)
         elif order == "sort":
-            ordered_table = self.sort(*columns)
+            ordered_df = self.sort(*columns)
         else:
             raise TypeError(
                 f"For order, expected 'original', 'cluster', or 'sort', but got {order!r}"
             )
 
-        return DataTable(ordered_table._df, self.group_levels + (columns,), self.height)
+        return DataFrame(ordered_df._df, self.group_levels + (columns,), self.height)
 
     def group(
         self, *columns: str, order: Literal["original", "cluster", "sort"] = "original"
-    ) -> DataTable:
+    ) -> DataFrame:
         return self.group_by(*columns, order=order)
 
-    def ungroup(self) -> DataTable:
+    def ungroup(self) -> DataFrame:
         if len(self.group_levels) == 0:
             raise NoGroups()
         else:
-            return DataTable(self._df, self.group_levels[:-1], self.height)
+            return DataFrame(self._df, self.group_levels[:-1], self.height)
 
-    def summarize(self, **reducers: str) -> DataTable:
+    def summarize(self, **reducers: str) -> DataFrame:
         if len(self.group_levels) == 0:
             raise NoGroups()
 
@@ -424,7 +424,7 @@ class DataTable:
             return self.select().distinct().ungroup()
         else:
             if self.width == 0:
-                df = dummy_table(self.height)
+                df = dummy_frame(self.height)
             else:
                 df = self._df
 
@@ -432,9 +432,9 @@ class DataTable:
                 polars_expressions
             )
 
-            return DataTable(summarized, self.group_levels[:-1])
+            return DataFrame(summarized, self.group_levels[:-1])
 
-    def spread(self, key: str, value: str, *, fill: Any = error) -> DataTable:
+    def spread(self, key: str, value: str, *, fill: Any = error) -> DataFrame:
         if len(self.group_levels) == 0:
             raise NoGroups()
 
@@ -442,9 +442,9 @@ class DataTable:
 
         df = self._df.pivot(index=list(self.group_names), columns=key, values=value)
 
-        return DataTable(df, self.group_levels[:-1])
+        return DataFrame(df, self.group_levels[:-1])
 
-    def gather(self, key: str, value: str, *columns: str) -> DataTable:
+    def gather(self, key: str, value: str, *columns: str) -> DataFrame:
         column_set = set(columns)
         all_columns = [column for column in self.column_names if column not in column_set]
 
@@ -452,7 +452,7 @@ class DataTable:
             id_vars=all_columns, value_vars=list(columns), variable_name=key, value_name=value
         )
 
-        return DataTable(df, self.group_levels).group_by(key)
+        return DataFrame(df, self.group_levels).group_by(key)
 
     def _resolve_join_by(
         self,
@@ -486,13 +486,15 @@ class DataTable:
 
     def inner_join(
         self,
-        other: DataTable,
+        other: DataFrame,
         /,
         *,
         by: Optional[Sequence[Union[str, tuple[str, str]]]] = None,
-    ) -> DataTable:
+    ) -> DataFrame:
         if len(self.group_levels) != 0 or len(other.group_levels) != 0:
-            raise NotImplementedError("Joins using grouped tables is not currently implemented")
+            raise NotImplementedError(
+                "Joins using grouped data frames is not currently implemented"
+            )
 
         left_key_columns, right_key_columns = self._resolve_join_by(by, other.column_names)
 
@@ -511,17 +513,19 @@ class DataTable:
             .collect()
         )
 
-        return DataTable(joined_df)
+        return DataFrame(joined_df)
 
     def left_join(
         self,
-        other: DataTable,
+        other: DataFrame,
         /,
         *,
         by: Optional[Sequence[Union[str, tuple[str, str]]]] = None,
-    ) -> DataTable:
+    ) -> DataFrame:
         if len(self.group_levels) != 0 or len(other.group_levels) != 0:
-            raise NotImplementedError("Joins using grouped tables is not currently implemented")
+            raise NotImplementedError(
+                "Joins using grouped data frames is not currently implemented"
+            )
 
         left_key_columns, right_key_columns = self._resolve_join_by(by, other.column_names)
 
@@ -539,19 +543,21 @@ class DataTable:
             .drop(["_index1", "_index2"])
             .collect()
         )
-        return DataTable(
+        return DataFrame(
             joined_df,
         )
 
     def outer_join(
         self,
-        other: DataTable,
+        other: DataFrame,
         /,
         *,
         by: Optional[Sequence[Union[str, tuple[str, str]]]] = None,
-    ) -> DataTable:
+    ) -> DataFrame:
         if len(self.group_levels) != 0 or len(other.group_levels) != 0:
-            raise NotImplementedError("Joins using grouped tables is not currently implemented")
+            raise NotImplementedError(
+                "Joins using grouped data frames is not currently implemented"
+            )
 
         left_key_columns, right_key_columns = self._resolve_join_by(by, other.column_names)
 
@@ -569,17 +575,17 @@ class DataTable:
             .drop(["_index1", "_index2"])
             .collect()
         )
-        return DataTable(
+        return DataFrame(
             joined_df,
         )
 
     def __eq__(self, other):
-        if isinstance(other, DataTable):
+        if isinstance(other, DataFrame):
             if self.group_levels != other.group_levels:
                 return False
 
             if self.width == 0:
-                # Polars does not understand columnless tables
+                # Polars does not understand columnless data frames
                 return self.height == other.height
 
             if self.height == 0:
@@ -594,7 +600,7 @@ class DataTable:
     def __repr__(self):
         column_strs = [f"{name} = {list(values)!r}" for name, values in self._df.to_dict().items()]
         group_strs = [f".group_by({', '.join(map(repr, level))})" for level in self.group_levels]
-        return f"DataTable({', '.join(column_strs)}){''.join(group_strs)}"
+        return f"DataFrame({', '.join(column_strs)}){''.join(group_strs)}"
 
     def __str__(self):
         if len(self.group_levels) == 0:

--- a/src/tabeline/_dummy.py
+++ b/src/tabeline/_dummy.py
@@ -1,11 +1,11 @@
-__all__ = ["dummy_name", "dummy_table"]
+__all__ = ["dummy_name", "dummy_frame"]
 
 import polars as pl
 
 dummy_name = "_dummy"
 
 
-def dummy_table(height: int) -> pl.DataFrame:
+def dummy_frame(height: int) -> pl.DataFrame:
     # Lots of things in Polars don't work if the DataFrame has no columns
-    # This constructs an effectively columnless table with the correct height
+    # This constructs an effectively columnless data frame with the correct height
     return pl.DataFrame({dummy_name: pl.repeat(False, height, eager=True)})

--- a/src/tabeline/exceptions.py
+++ b/src/tabeline/exceptions.py
@@ -35,12 +35,12 @@ class RenameExisting(TabelineException):
 
 class HasGroups(TabelineException):
     def __str__(self) -> str:
-        return "Cannot perform this operation on a table with any group levels"
+        return "Cannot perform this operation on a data frame with any group levels"
 
 
 class NoGroups(TabelineException):
     def __str__(self) -> str:
-        return "Cannot perform this operation on a table with no group levels"
+        return "Cannot perform this operation on a data frame with no group levels"
 
 
 class GroupColumn(TabelineException):
@@ -52,9 +52,9 @@ class GroupColumn(TabelineException):
         return f"Cannot perform this operation on group column {self.column}"
 
 
-class RowlessTable(TabelineException):
+class RowlessDataFrame(TabelineException):
     def __str__(self) -> str:
-        return "Cannot perform this operation on a table with no rows"
+        return "Cannot perform this operation on a data frame with no rows"
 
 
 class IndexOutOfRange(TabelineException):
@@ -63,4 +63,4 @@ class IndexOutOfRange(TabelineException):
         self.length = length
 
     def __str__(self) -> str:
-        return f"Cannot index element {self.index} from table with {self.length} rows"
+        return f"Cannot index element {self.index} from data frame with {self.length} rows"

--- a/src/tabeline/testing.py
+++ b/src/tabeline/testing.py
@@ -1,10 +1,10 @@
 from polars.testing import assert_frame_equal
 
-from ._data_table import DataTable
+from ._data_frame import DataFrame
 
 
-def assert_table_equal(
-    left: DataTable, right: DataTable, reltol: float = 0.0, abstol: float = 0.0
+def assert_data_frame_equal(
+    left: DataFrame, right: DataFrame, reltol: float = 0.0, abstol: float = 0.0
 ) -> None:
     assert left.shape == right.shape
     assert left.group_levels == right.group_levels

--- a/tests/_grouping.py
+++ b/tests/_grouping.py
@@ -1,9 +1,9 @@
 __all__ = ["apply_groups"]
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
-def apply_groups(table: DataTable, group_levels: tuple[tuple[str, ...], ...]) -> DataTable:
+def apply_groups(df: DataFrame, group_levels: tuple[tuple[str, ...], ...]) -> DataFrame:
     for group_level in group_levels:
-        table = table.group_by(*group_level)
-    return table
+        df = df.group_by(*group_level)
+    return df

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,33 +1,33 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_attributes():
-    table = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    assert table.height == 4
-    assert table.width == 3
-    assert table.shape == (4, 3)
-    assert table.column_names == ("x", "y", "z")
+    df = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    assert df.height == 4
+    assert df.width == 3
+    assert df.shape == (4, 3)
+    assert df.column_names == ("x", "y", "z")
 
 
 def test_attributes_empty():
-    table = DataTable()
-    assert table.height == 0
-    assert table.width == 0
-    assert table.shape == (0, 0)
-    assert table.column_names == ()
+    df = DataFrame()
+    assert df.height == 0
+    assert df.width == 0
+    assert df.shape == (0, 0)
+    assert df.column_names == ()
 
 
 def test_attributes_columnless():
-    table = DataTable.columnless(height=6)
-    assert table.height == 6
-    assert table.width == 0
-    assert table.shape == (6, 0)
-    assert table.column_names == ()
+    df = DataFrame.columnless(height=6)
+    assert df.height == 6
+    assert df.width == 0
+    assert df.shape == (6, 0)
+    assert df.column_names == ()
 
 
 def test_attributes_rowless():
-    table = DataTable(x=[], y=[], z=[])
-    assert table.height == 0
-    assert table.width == 3
-    assert table.shape == (0, 3)
-    assert table.column_names == ("x", "y", "z")
+    df = DataFrame(x=[], y=[], z=[])
+    assert df.height == 0
+    assert df.width == 3
+    assert df.shape == (0, 3)
+    assert df.column_names == ("x", "y", "z")

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,82 +1,80 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_cluster():
-    table = DataTable(x=[1, 0, 1, 0], y=[3, 1, 2, 4])
-    actual = table.cluster("x")
-    expected = DataTable(x=[1, 1, 0, 0], y=[3, 2, 1, 4])
+    df = DataFrame(x=[1, 0, 1, 0], y=[3, 1, 2, 4])
+    actual = df.cluster("x")
+    expected = DataFrame(x=[1, 1, 0, 0], y=[3, 2, 1, 4])
     assert actual == expected
 
 
 def test_cluster_two():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6])
-    actual = table.cluster("x", "y")
-    expected = DataTable(x=[2, 2, 2, 2, 1, 1], y=[3, 3, 4, 4, 4, 3], z=[1, 6, 2, 5, 3, 4])
+    df = DataFrame(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6])
+    actual = df.cluster("x", "y")
+    expected = DataFrame(x=[2, 2, 2, 2, 1, 1], y=[3, 3, 4, 4, 4, 3], z=[1, 6, 2, 5, 3, 4])
     assert actual == expected
 
 
 def test_cluster_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6]).group_by(
-        "x"
-    )
-    actual = table.cluster("y")
-    expected = DataTable(
+    df = DataFrame(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 4, 3, 4, 3], z=[1, 2, 3, 4, 5, 6]).group_by("x")
+    actual = df.cluster("y")
+    expected = DataFrame(
         x=[2, 2, 1, 1, 2, 2], y=[3, 3, 4, 3, 4, 4], z=[1, 6, 3, 4, 2, 5]
     ).group_by("x")
     assert actual == expected
 
 
 def test_cluster_grouped_two():
-    table = DataTable(
+    df = DataFrame(
         x=[2, 2, 1, 1, 2, 2, 2], y=[3, 4, 4, 4, 4, 3, 4], z=[2, 1, 1, 1, 2, 1, 1]
     ).group_by("x", "y")
-    actual = table.cluster("z")
-    expected = DataTable(
+    actual = df.cluster("z")
+    expected = DataFrame(
         x=[2, 2, 1, 1, 2, 2, 2], y=[3, 4, 4, 4, 4, 3, 4], z=[2, 1, 1, 1, 1, 1, 2]
     ).group_by("x", "y")
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_cluster_empty(table):
-    actual = table.cluster()
-    assert actual == table
+def test_cluster_empty(df):
+    actual = df.cluster()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_cluster_columnless(table):
-    actual = table.cluster()
-    assert actual == table
+def test_cluster_columnless(df):
+    actual = df.cluster()
+    assert actual == df
 
 
 @pytest.mark.parametrize("columns", [[], ["z"], ["z", "y"], ["y", "z"]])
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[], z=[]).group_by(),
-        DataTable(x=[], y=[], z=[]).group_by().group_by(),
-        DataTable(x=[], y=[], z=[]).group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "w"),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[], z=[]).group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("x", "w"),
     ],
 )
-def test_cluster_rowless(columns, table):
-    actual = table.cluster()
-    assert actual == table
+def test_cluster_rowless(columns, df):
+    actual = df.cluster()
+    assert actual == df

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3,19 +3,19 @@ from pathlib import Path
 
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
-        DataTable(escape=["a a", "c,c", r"s\s", 'q"q', "q'q", "n\nn"]),
+        DataFrame(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
+        DataFrame(escape=["a a", "c,c", r"s\s", 'q"q', "q'q", "n\nn"]),
     ],
 )
-def test_csv_roundtrip(table):
+def test_csv_roundtrip(df):
     with tempfile.TemporaryDirectory() as directory:
         path = Path(directory).joinpath("temp.csv")
-        table.write_csv(path)
-        actual = DataTable.read_csv(path)
-    assert actual == table
+        df.write_csv(path)
+        actual = DataFrame.read_csv(path)
+    assert actual == df

--- a/tests/test_deselect.py
+++ b/tests/test_deselect.py
@@ -2,14 +2,14 @@ from typing import Any
 
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import GroupColumn, NonexistentColumn
 
 
 def test_deselect():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.deselect("x", "z")
-    expected = DataTable(y=[True, False, True])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.deselect("x", "z")
+    expected = DataFrame(y=[True, False, True])
     assert actual == expected
 
 
@@ -47,50 +47,50 @@ def test_deselect_columns(
     expected_columns: list[str],
     test_columns: dict[str, Any],
 ):
-    table = DataTable(**{name: full_columns[name] for name in input_columns})
-    actual = table.deselect(*deselectors)
+    df = DataFrame(**{name: full_columns[name] for name in input_columns})
+    actual = df.deselect(*deselectors)
     if len(expected_columns) == 0:
-        expected = DataTable.columnless(height=table.height)
+        expected = DataFrame.columnless(height=df.height)
     else:
-        expected = DataTable(**{name: full_columns[name] for name in expected_columns})
+        expected = DataFrame(**{name: full_columns[name] for name in expected_columns})
     assert actual == expected
 
 
 def test_deselect_nonexistent_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
 
     with pytest.raises(NonexistentColumn):
-        _ = table.deselect("x", "a")
+        _ = df.deselect("x", "a")
 
 
 def test_deselect_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
 
     with pytest.raises(GroupColumn):
-        _ = table.deselect("x")
+        _ = df.deselect("x")
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_deselect_empty(table):
-    actual = table.deselect()
-    assert actual == table
+def test_deselect_empty(df):
+    actual = df.deselect()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_deselect_columnless(table):
-    actual = table.deselect()
-    assert actual == table
+def test_deselect_columnless(df):
+    actual = df.deselect()
+    assert actual == df

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -1,46 +1,46 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_distinct():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.distinct("x")
-    expected = DataTable(x=[0, 1], y=[1, 3])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.distinct("x")
+    expected = DataFrame(x=[0, 1], y=[1, 3])
     assert actual == expected
 
 
 def test_distinct_unsorted():
-    table = DataTable(x=[1, 1, 0, 0], y=[1, 2, 3, 4])
-    actual = table.distinct("x")
-    expected = DataTable(x=[1, 0], y=[1, 3])
+    df = DataFrame(x=[1, 1, 0, 0], y=[1, 2, 3, 4])
+    actual = df.distinct("x")
+    expected = DataFrame(x=[1, 0], y=[1, 3])
     assert actual == expected
 
 
 def test_empty_distinct():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.distinct()
-    expected = DataTable(x=[0], y=[1])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.distinct()
+    expected = DataFrame(x=[0], y=[1])
     assert actual == expected
 
 
 @pytest.mark.parametrize("distinct_columns", [["z"], ["x", "z"], ["z", "x"]])
 def test_distinct_with_grouped_column(distinct_columns):
-    table = DataTable(
+    df = DataFrame(
         x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
     ).group_by("x")
-    actual = table.distinct(*distinct_columns)
-    expected = DataTable(x=[0, 1, 1, 1], y=["a", "a", "a", "b"], z=[1, 1, 2, 3]).group_by("x")
+    actual = df.distinct(*distinct_columns)
+    expected = DataFrame(x=[0, 1, 1, 1], y=["a", "a", "a", "b"], z=[1, 1, 2, 3]).group_by("x")
     assert actual == expected
 
 
 @pytest.mark.parametrize("distinct_columns", [["z"], ["y", "z"], ["x", "z"]])
 def test_distinct_with_two_grouped_columns(distinct_columns):
-    table = DataTable(
+    df = DataFrame(
         x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
     ).group_by("x", "y")
-    actual = table.distinct(*distinct_columns)
-    expected = DataTable(
+    actual = df.distinct(*distinct_columns)
+    expected = DataFrame(
         x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3]
     ).group_by("x", "y")
     assert actual == expected
@@ -48,16 +48,16 @@ def test_distinct_with_two_grouped_columns(distinct_columns):
 
 @pytest.mark.parametrize("distinct_columns", [["z"], ["y", "z"], ["x", "z"]])
 def test_distinct_with_two_separate_grouped_columns(distinct_columns):
-    table = (
-        DataTable(
+    df = (
+        DataFrame(
             x=[0, 0, 0, 1, 1, 1, 1], y=["a", "a", "b", "a", "a", "b", "b"], z=[1, 1, 1, 1, 2, 3, 3]
         )
         .group_by("x")
         .group_by("y")
     )
-    actual = table.distinct(*distinct_columns)
+    actual = df.distinct(*distinct_columns)
     expected = (
-        DataTable(x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3])
+        DataFrame(x=[0, 0, 1, 1, 1], y=["a", "b", "a", "a", "b"], z=[1, 1, 1, 2, 3])
         .group_by("x")
         .group_by("y")
     )
@@ -65,43 +65,43 @@ def test_distinct_with_two_separate_grouped_columns(distinct_columns):
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_distinct_on_empty(table):
-    actual = table.distinct()
-    assert actual == table
+def test_distinct_on_empty(df):
+    actual = df.distinct()
+    assert actual == df
 
 
 @pytest.mark.parametrize("columns", [[], ["x"], ["x", "y"], ["y", "x"]])
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group_by(),
-        DataTable(x=[], y=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[]).group_by(),
+        DataFrame(x=[], y=[]).group_by().group_by(),
     ],
 )
-def test_distinct_on_rowless(columns, table):
-    actual = table.distinct(*columns)
-    assert actual == table
+def test_distinct_on_rowless(columns, df):
+    actual = df.distinct(*columns)
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    ["table", "expected"],
+    ["df", "expected"],
     [
-        [DataTable.columnless(height=6), DataTable.columnless(height=1)],
-        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=1).group_by()],
+        [DataFrame.columnless(height=6), DataFrame.columnless(height=1)],
+        [DataFrame.columnless(height=6).group_by(), DataFrame.columnless(height=1).group_by()],
         [
-            DataTable.columnless(height=6).group_by().group_by(),
-            DataTable.columnless(height=1).group_by().group_by(),
+            DataFrame.columnless(height=6).group_by().group_by(),
+            DataFrame.columnless(height=1).group_by().group_by(),
         ],
     ],
 )
-def test_distinct_on_columnless(table, expected):
-    actual = table.distinct()
+def test_distinct_on_columnless(df, expected):
+    actual = df.distinct()
     assert actual == expected

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,83 +1,83 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
-def test_tables_are_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+def test_data_frames_are_equal():
+    first = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    second = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
     assert first == second
 
 
-def test_tables_are_not_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    second = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 10.1])
+def test_data_frames_are_not_equal():
+    first = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    second = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 10.1])
     assert first != second
 
 
-def test_table_equal_to_itself():
-    table = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    assert table == table
+def test_data_frame_equal_to_itself():
+    df = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    assert df == df
 
 
-def test_empty_tables_are_equal():
-    first = DataTable()
-    second = DataTable()
+def test_empty_data_frames_are_equal():
+    first = DataFrame()
+    second = DataFrame()
     assert first == second
 
 
-def test_empty_table_equal_to_itself():
-    table = DataTable()
-    assert table == table
+def test_empty_data_frame_equal_to_itself():
+    df = DataFrame()
+    assert df == df
 
 
-def test_rowless_table_equal():
-    first = DataTable(x=[], y=[], z=[])
-    second = DataTable(x=[], y=[], z=[])
+def test_rowless_data_frame_equal():
+    first = DataFrame(x=[], y=[], z=[])
+    second = DataFrame(x=[], y=[], z=[])
     assert first == second
 
 
-def test_rowless_table_equal_to_itself():
-    table = DataTable(x=[], y=[], z=[])
-    assert table == table
+def test_rowless_data_frame_equal_to_itself():
+    df = DataFrame(x=[], y=[], z=[])
+    assert df == df
 
 
-def test_columnless_tables_are_equal():
-    first = DataTable.columnless(height=6)
-    second = DataTable.columnless(height=6)
+def test_columnless_data_frames_are_equal():
+    first = DataFrame.columnless(height=6)
+    second = DataFrame.columnless(height=6)
     assert first == second
 
 
-def test_columnless_table_equal_to_itself():
-    table = DataTable.columnless(height=6)
-    assert table == table
+def test_columnless_data_frame_equal_to_itself():
+    df = DataFrame.columnless(height=6)
+    assert df == df
 
 
 def test_reordered_rows_are_not_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    second = DataTable(x=[1, 2, 4, 3], y=[True, False, True, True], z=[3.5, 2.2, 8.9, 6.7])
+    first = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    second = DataFrame(x=[1, 2, 4, 3], y=[True, False, True, True], z=[3.5, 2.2, 8.9, 6.7])
     assert first != second
 
 
 def test_reordered_columns_are_not_equal():
-    first = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
-    second = DataTable(x=[1, 2, 3, 4], z=[3.5, 2.2, 6.7, 8.9], y=[True, False, True, True])
+    first = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    second = DataFrame(x=[1, 2, 3, 4], z=[3.5, 2.2, 6.7, 8.9], y=[True, False, True, True])
     assert first != second
 
 
-def test_grouped_tables_are_equal():
-    first = DataTable(
+def test_grouped_data_frames_are_equal():
+    first = DataFrame(
         x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]
     ).group_by("x")
-    second = DataTable(
+    second = DataFrame(
         x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]
     ).group_by("x")
     assert first == second
 
 
-def test_grouped_tables_with_differnt_levels_are_not_equal():
-    first = DataTable(
+def test_grouped_data_frames_with_different_levels_are_not_equal():
+    first = DataFrame(
         x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]
     ).group_by("x")
-    second = DataTable(
+    second = DataFrame(
         x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9]
     ).group_by("y")
     assert first != second

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,104 +1,104 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_filter():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.filter("x == max(x)")
-    expected = DataTable(x=[1, 1], y=[3, 4])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.filter("x == max(x)")
+    expected = DataFrame(x=[1, 1], y=[3, 4])
     assert actual == expected
 
 
 def test_grouped_filter():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
-    actual = table.filter("y == max(y)")
-    expected = DataTable(x=[0, 1, 1], y=[2, 3, 3]).group_by("x")
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
+    actual = df.filter("y == max(y)")
+    expected = DataFrame(x=[0, 1, 1], y=[2, 3, 3]).group_by("x")
     assert actual == expected
 
 
 def test_filter_out_all_rows():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.filter("x == 2")
-    expected = DataTable(x=[], y=[])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.filter("x == 2")
+    expected = DataFrame(x=[], y=[])
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
+        DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
+        DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
+        DataFrame(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
+        DataFrame(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
         .group_by("x")
         .group_by("y"),
     ],
 )
-def test_filter_true(table):
-    actual = table.filter("True")
-    assert actual == table
+def test_filter_true(df):
+    actual = df.filter("True")
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
-        DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
-        DataTable(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
+        DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]),
+        DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x"),
+        DataFrame(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3]).group_by("x", "y"),
+        DataFrame(x=[0, 0, 1, 1], y=[True, False, False, True], z=[1, 2, 3, 3])
         .group_by("x")
         .group_by("y"),
     ],
 )
-def test_filter_false(table):
-    actual = table.filter("False")
-    expected = table.slice0([])
+def test_filter_false(df):
+    actual = df.filter("False")
+    expected = df.slice0([])
     assert actual == expected
 
 
 @pytest.mark.parametrize("expression", ["True", "False", "row_index1() == 1"])
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_filter_empty(expression, table):
-    actual = table.filter(expression)
-    assert actual == table
+def test_filter_empty(expression, df):
+    actual = df.filter(expression)
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    ["table", "expected"],
+    ["df", "expected"],
     [
-        [DataTable.columnless(height=6), DataTable.columnless(height=3)],
-        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=3).group_by()],
+        [DataFrame.columnless(height=6), DataFrame.columnless(height=3)],
+        [DataFrame.columnless(height=6).group_by(), DataFrame.columnless(height=3).group_by()],
         [
-            DataTable.columnless(height=6).group_by().group_by(),
-            DataTable.columnless(height=3).group_by().group_by(),
+            DataFrame.columnless(height=6).group_by().group_by(),
+            DataFrame.columnless(height=3).group_by().group_by(),
         ],
     ],
 )
-def test_filter_columnless(table, expected):
-    actual = table.filter("row_index0() % 2 == 0")
+def test_filter_columnless(df, expected):
+    actual = df.filter("row_index0() % 2 == 0")
     assert actual == expected
 
 
 @pytest.mark.parametrize("expression", ["True", "False", "row_index1() == 1"])
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group_by(),
-        DataTable(x=[]).group_by().group_by(),
-        DataTable(x=[], y=[], z=[]).group_by("x"),
-        DataTable(x=[], y=[], z=[]).group_by("x", "y"),
-        DataTable(x=[], y=[], z=[]).group_by("x").group_by("y"),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[]).group_by(),
+        DataFrame(x=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by("x"),
+        DataFrame(x=[], y=[], z=[]).group_by("x", "y"),
+        DataFrame(x=[], y=[], z=[]).group_by("x").group_by("y"),
     ],
 )
-def test_filter_rowless(expression, table):
-    actual = table.filter(expression)
-    assert actual == table
+def test_filter_rowless(expression, df):
+    actual = df.filter(expression)
+    assert actual == df

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,8 +2,8 @@ import math
 
 import pytest
 
-from tabeline import DataTable
-from tabeline.testing import assert_table_equal
+from tabeline import DataFrame
+from tabeline.testing import assert_data_frame_equal
 
 from ._xfail import xfail_param
 
@@ -58,49 +58,49 @@ one_argument_functions = [
 )
 def test_single_numeric_argument_against_python(name, function):
     values = [0.5, 1.0, math.pi]
-    table = DataTable(x=values)
-    actual = table.transmute(y=f"{name}(x)")
-    expected = DataTable(y=[function(value) for value in values])
-    assert_table_equal(actual, expected, reltol=1e-8)
+    df = DataFrame(x=values)
+    actual = df.transmute(y=f"{name}(x)")
+    expected = DataFrame(y=[function(value) for value in values])
+    assert_data_frame_equal(actual, expected, reltol=1e-8)
 
 
 @pytest.mark.parametrize("name", zero_argument_functions)
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
-        DataTable(a=[]).group_by("a"),
-        DataTable(a=[], b=[]).group_by("a", "b"),
-        DataTable(a=[], b=[]).group_by("a").group_by("b"),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
+        DataFrame(a=[]).group_by("a"),
+        DataFrame(a=[], b=[]).group_by("a", "b"),
+        DataFrame(a=[], b=[]).group_by("a").group_by("b"),
     ],
 )
-def test_zero_argument_functions_on_rowless_table_with_mutate(name, table):
-    actual = table.mutate(x=f"{name}()")
-    expected = table.mutate(x="1")
+def test_zero_argument_functions_on_rowless_data_frame_with_mutate(name, df):
+    actual = df.mutate(x=f"{name}()")
+    expected = df.mutate(x="1")
     assert actual == expected
 
 
 @pytest.mark.parametrize("name", zero_argument_functions)
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
         # Polars chokes on empty list in groupby
         # https://github.com/pola-rs/polars/issues/3041
-        xfail_param(DataTable()),
-        xfail_param(DataTable().group_by()),
-        xfail_param(DataTable().group_by().group_by()),
-        xfail_param(DataTable(a=[])),
-        DataTable(a=[]).group_by("a"),
-        DataTable(a=[], b=[]).group_by("a", "b"),
-        DataTable(a=[], b=[]).group_by("a").group_by("b"),
+        xfail_param(DataFrame()),
+        xfail_param(DataFrame().group_by()),
+        xfail_param(DataFrame().group_by().group_by()),
+        xfail_param(DataFrame(a=[])),
+        DataFrame(a=[]).group_by("a"),
+        DataFrame(a=[], b=[]).group_by("a", "b"),
+        DataFrame(a=[], b=[]).group_by("a").group_by("b"),
     ],
 )
-def test_zero_argument_functions_on_rowless_table_with_summarize(name, table):
-    expected = table.mutate(x="1")
+def test_zero_argument_functions_on_rowless_data_frame_with_summarize(name, df):
+    expected = df.mutate(x="1")
 
-    actual = table.group_by().summarize(x=f"{name}()")
+    actual = df.group_by().summarize(x=f"{name}()")
     assert actual == expected
 
 
@@ -110,30 +110,30 @@ def test_zero_argument_functions_on_rowless_table_with_summarize(name, table):
     "name", [xfail_param(f) if f in ("all", "any") else f for f in one_argument_functions]
 )
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(a=[]),
-        DataTable(a=[]).group_by(),
-        DataTable(a=[]).group_by().group_by(),
-        DataTable(a=[]).group_by("a"),
-        DataTable(a=[], b=[], c=[]).group_by("a", "b"),
-        DataTable(a=[], b=[], c=[]).group_by("a").group_by("b"),
+        DataFrame(a=[]),
+        DataFrame(a=[]).group_by(),
+        DataFrame(a=[]).group_by().group_by(),
+        DataFrame(a=[]).group_by("a"),
+        DataFrame(a=[], b=[], c=[]).group_by("a", "b"),
+        DataFrame(a=[], b=[], c=[]).group_by("a").group_by("b"),
     ],
 )
-def test_one_argument_functions_on_rowless_table_with_mutate(name, table):
-    actual = table.mutate(x=f"{name}(a)")
-    expected = table.mutate(x="1")
+def test_one_argument_functions_on_rowless_data_frame_with_mutate(name, df):
+    actual = df.mutate(x=f"{name}(a)")
+    expected = df.mutate(x="1")
     assert actual == expected
 
 
 def test_quantile():
-    actual = DataTable(x=[20, 21, 22]).mutate(q="quantile(x, 0.75)")
-    expected = DataTable(x=[20, 21, 22], q=[21.5, 21.5, 21.5])
-    assert_table_equal(actual, expected, reltol=1e-8)
+    actual = DataFrame(x=[20, 21, 22]).mutate(q="quantile(x, 0.75)")
+    expected = DataFrame(x=[20, 21, 22], q=[21.5, 21.5, 21.5])
+    assert_data_frame_equal(actual, expected, reltol=1e-8)
 
 
 def test_trapz():
-    table = DataTable(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4])
-    actual = table.group_by("id").summarize(q="trapz(t, y)")
-    expected = DataTable(id=[0, 1], q=[2.0, 13.0])
-    assert_table_equal(actual, expected, reltol=1e-8)
+    df = DataFrame(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4])
+    actual = df.group_by("id").summarize(q="trapz(t, y)")
+    expected = DataFrame(id=[0, 1], q=[2.0, 13.0])
+    assert_data_frame_equal(actual, expected, reltol=1e-8)

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -1,10 +1,10 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_gather():
-    table = DataTable.from_dict({"sex": ["M", "F"], "0": [8, 9], "1": [9, 10], "2": [6, 9]})
-    actual = table.gather("grades", "count", "0", "1", "2")
-    expected = DataTable(
+    df = DataFrame.from_dict({"sex": ["M", "F"], "0": [8, 9], "1": [9, 10], "2": [6, 9]})
+    actual = df.gather("grades", "count", "0", "1", "2")
+    expected = DataFrame(
         sex=["M", "F", "M", "F", "M", "F"],
         grades=["0", "0", "1", "1", "2", "2"],
         count=[8, 9, 9, 10, 6, 9],

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,41 +1,41 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import GroupColumn
 
 
 def test_group_by():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
-    assert table.group_levels == (("x",),)
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
+    assert df.group_levels == (("x",),)
 
 
 def test_group_by_multiple_columns():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x", "y")
-    assert table.group_levels == (("x", "y"),)
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x", "y")
+    assert df.group_levels == (("x", "y"),)
 
 
 def test_group_by_multiple_levels():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x").group_by("y")
-    assert table.group_levels == (("x",), ("y",))
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x").group_by("y")
+    assert df.group_levels == (("x",), ("y",))
 
 
 def test_group_by_same_column_twice():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4]).group_by("x")
     with pytest.raises(GroupColumn):
-        _ = table.group_by("x")
+        _ = df.group_by("x")
 
 
 def test_group_by_cluster():
-    table = DataTable(x=[1, 0, 1, 0], y=[3, 1, 2, 4])
-    actual = table.group_by("x", order="cluster")
-    expected = DataTable(x=[1, 1, 0, 0], y=[3, 2, 1, 4]).group_by("x")
+    df = DataFrame(x=[1, 0, 1, 0], y=[3, 1, 2, 4])
+    actual = df.group_by("x", order="cluster")
+    expected = DataFrame(x=[1, 1, 0, 0], y=[3, 2, 1, 4]).group_by("x")
     assert actual == expected
 
 
 def test_group_by_sort():
-    table = DataTable(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
-    actual = table.group_by("x", order="sort")
-    expected = DataTable(
+    df = DataFrame(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
+    actual = df.group_by("x", order="sort")
+    expected = DataFrame(
         x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 3.4, 2.1, 0.0], z=[2, 1, 4, 5, 3]
     ).group_by("x")
     assert actual == expected

--- a/tests/test_inner_join.py
+++ b/tests/test_inner_join.py
@@ -1,23 +1,23 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_inner_join():
-    table1 = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
-    table2 = DataTable(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
+    df2 = DataFrame(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
 
-    actual = table1.inner_join(table2)
+    actual = df1.inner_join(df2)
 
-    expected = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
+    expected = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
 
     assert actual == expected
 
 
 def test_inner_join_ignore_unmatched():
-    table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-    table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+    df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-    actual = table1.inner_join(table2)
+    actual = df1.inner_join(df2)
 
-    expected = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
+    expected = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
 
     assert actual == expected

--- a/tests/test_left_join.py
+++ b/tests/test_left_join.py
@@ -1,24 +1,24 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_left_join():
-    table1 = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
-    table2 = DataTable(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
+    df2 = DataFrame(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
 
-    actual = table1.left_join(table2)
+    actual = df1.left_join(df2)
 
-    expected = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
+    expected = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
 
     assert actual == expected
 
 
 def test_left_join_ignore_right_unmatched():
-    table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-    table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+    df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-    actual = table1.left_join(table2)
+    actual = df1.left_join(df2)
 
-    expected = DataTable(
+    expected = DataFrame(
         x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"], z=["d", "c", "b", "a", None]
     )
 

--- a/tests/test_mutate.py
+++ b/tests/test_mutate.py
@@ -1,102 +1,102 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import GroupColumn
 
 
 def test_mutate():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True])
-    actual = table.mutate(z="x + 1")
-    expected = DataTable(x=[0, 0, 1], y=[True, False, True], z=[1, 1, 2])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True])
+    actual = df.mutate(z="x + 1")
+    expected = DataFrame(x=[0, 0, 1], y=[True, False, True], z=[1, 1, 2])
     assert actual == expected
 
 
 def test_mutate_grouped():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
-    actual = table.mutate(z="y + 1")
-    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
+    df = DataFrame(x=[True, False, True], y=[0, 0, 1]).group_by("x")
+    actual = df.mutate(z="y + 1")
+    expected = DataFrame(x=[True, False, True], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_referencing_group():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
-    actual = table.mutate(z="~x")
-    expected = DataTable(x=[True, False, True], y=[0, 0, 1], z=[False, True, False]).group_by("x")
+    df = DataFrame(x=[True, False, True], y=[0, 0, 1]).group_by("x")
+    actual = df.mutate(z="~x")
+    expected = DataFrame(x=[True, False, True], y=[0, 0, 1], z=[False, True, False]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_overwrite():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True])
-    actual = table.mutate(x="x + 1")
-    expected = DataTable(x=[1, 1, 2], y=[True, False, True])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True])
+    actual = df.mutate(x="x + 1")
+    expected = DataFrame(x=[1, 1, 2], y=[True, False, True])
     assert actual == expected
 
 
 def test_mutate_overwrite_grouped():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
-    actual = table.mutate(y="y + 1")
-    expected = DataTable(x=[True, False, True], y=[1, 1, 2]).group_by("x")
+    df = DataFrame(x=[True, False, True], y=[0, 0, 1]).group_by("x")
+    actual = df.mutate(y="y + 1")
+    expected = DataFrame(x=[True, False, True], y=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_overwrite_referencing_group():
-    table = DataTable(x=[True, False, True], y=[0, 0, 1]).group_by("x")
-    actual = table.mutate(y="~x")
-    expected = DataTable(x=[True, False, True], y=[False, True, False]).group_by("x")
+    df = DataFrame(x=[True, False, True], y=[0, 0, 1]).group_by("x")
+    actual = df.mutate(y="~x")
+    expected = DataFrame(x=[True, False, True], y=[False, True, False]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_reference_previous_mutator():
-    table = DataTable(x=[0, 0, 1])
-    actual = table.mutate(y="x + 1", z="2*y")
-    expected = DataTable(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4])
+    df = DataFrame(x=[0, 0, 1])
+    actual = df.mutate(y="x + 1", z="2*y")
+    expected = DataFrame(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4])
     assert actual == expected
 
 
 def test_mutate_reference_previous_mutator_grouped():
-    table = DataTable(x=[0, 0, 1]).group_by("x")
-    actual = table.mutate(y="max(x)", z="y+1")
-    expected = DataTable(x=[0, 0, 1], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
+    df = DataFrame(x=[0, 0, 1]).group_by("x")
+    actual = df.mutate(y="max(x)", z="y+1")
+    expected = DataFrame(x=[0, 0, 1], y=[0, 0, 1], z=[1, 1, 2]).group_by("x")
     assert actual == expected
 
 
 def test_mutate_broadcast_scalar():
-    table = DataTable(x=[0, 0, 1])
-    actual = table.mutate(max_x="max(x)")
-    expected = DataTable(x=[0, 0, 1], max_x=[1, 1, 1])
+    df = DataFrame(x=[0, 0, 1])
+    actual = df.mutate(max_x="max(x)")
+    expected = DataFrame(x=[0, 0, 1], max_x=[1, 1, 1])
     assert actual == expected
 
 
 def test_mutate_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group_by("x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True]).group_by("x")
     with pytest.raises(GroupColumn):
-        _ = table.mutate(x="x+1")
+        _ = df.mutate(x="x+1")
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_mutate_empty(table):
-    actual = table.mutate()
-    assert actual == table
+def test_mutate_empty(df):
+    actual = df.mutate()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_mutate_columnless(table):
-    actual = table.mutate()
-    assert actual == table
+def test_mutate_columnless(df):
+    actual = df.mutate()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
@@ -109,16 +109,16 @@ def test_mutate_columnless(table):
     ],
 )
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(w=[], x=[], y=[], z=[]),
-        DataTable(w=[], x=[], y=[], z=[]).group_by(),
-        DataTable(w=[], x=[], y=[], z=[]).group_by().group_by(),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "y"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("x").group_by("y"),
+        DataFrame(w=[], x=[], y=[], z=[]),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by(),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by().group_by(),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("x", "y"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("x").group_by("y"),
     ],
 )
-def test_mutate_rowless(expression, table):
-    actual = table.mutate(**expression)
-    assert actual == table
+def test_mutate_rowless(expression, df):
+    actual = df.mutate(**expression)
+    assert actual == df

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -3,8 +3,8 @@ import operator
 
 import pytest
 
-from tabeline import DataTable
-from tabeline.testing import assert_table_equal
+from tabeline import DataFrame
+from tabeline.testing import assert_data_frame_equal
 
 interesting_numbers = [1, 0, -5, 1.0, 0.0, -0.0, -15.3, math.inf, -math.inf, math.nan]
 
@@ -22,8 +22,8 @@ interesting_numbers = [1, 0, -5, 1.0, 0.0, -0.0, -15.3, math.inf, -math.inf, mat
     ],
 )
 def test_numeric_operators(left, right, operator, comparer):
-    table = DataTable(left=[left], right=[right])
-    actual = table.transmute(output=f"left {operator} right")
+    df = DataFrame(left=[left], right=[right])
+    actual = df.transmute(output=f"left {operator} right")
 
     try:
         output = comparer(left, right)
@@ -35,8 +35,8 @@ def test_numeric_operators(left, right, operator, comparer):
         # Python pow returns complex, while we want nan
         output = math.nan
 
-    expected = DataTable(output=[output])
-    assert_table_equal(actual, expected)
+    expected = DataFrame(output=[output])
+    assert_data_frame_equal(actual, expected)
 
 
 @pytest.mark.parametrize("left", interesting_numbers)
@@ -53,7 +53,7 @@ def test_numeric_operators(left, right, operator, comparer):
     ],
 )
 def test_comparison_operators(left, right, operator, comparer):
-    table = DataTable(left=[left], right=[right])
-    actual = table.transmute(output=f"left {operator} right")
-    expected = DataTable(output=[comparer(left, right)])
+    df = DataFrame(left=[left], right=[right])
+    actual = df.transmute(output=f"left {operator} right")
+    expected = DataFrame(output=[comparer(left, right)])
     assert actual == expected

--- a/tests/test_outer_join.py
+++ b/tests/test_outer_join.py
@@ -1,24 +1,24 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_outer_join():
-    table1 = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
-    table2 = DataTable(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"])
+    df2 = DataFrame(x=[3, 2, 1, 0], z=["a", "b", "c", "d"])
 
-    actual = table1.outer_join(table2)
+    actual = df1.outer_join(df2)
 
-    expected = DataTable(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
+    expected = DataFrame(x=[0, 1, 2, 3], y=["a", "b", "c", "d"], z=["d", "c", "b", "a"])
 
     assert actual == expected
 
 
 def test_outer_join_unmatched():
-    table1 = DataTable(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
-    table2 = DataTable(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
+    df1 = DataFrame(x=[0, 1, 2, 3, 4], y=["a", "b", "c", "d", "e"])
+    df2 = DataFrame(x=[3, 2, -1, 1, 0], z=["a", "b", "z", "c", "d"])
 
-    actual = table1.outer_join(table2)
+    actual = df1.outer_join(df2)
 
-    expected = DataTable(
+    expected = DataFrame(
         x=[-1, 0, 1, 2, 3, 4], y=[None, "a", "b", "c", "d", "e"], z=["z", "d", "c", "b", "a", None]
     )
 

--- a/tests/test_pandas_conversion.py
+++ b/tests/test_pandas_conversion.py
@@ -1,43 +1,40 @@
 import pytest
 
-try:
-    from pandas import DataFrame
-except ImportError:
-    pytest.skip("Pandas not available", allow_module_level=True)
+import tabeline as tb
 
-from tabeline import DataTable
+pd = pytest.importorskip("pandas")
 
 
 @pytest.mark.parametrize(
-    ["df", "table"],
+    ["pandas_df", "df"],
     [
         [
-            DataFrame(dict(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True])),
-            DataTable(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
+            pd.DataFrame(dict(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True])),
+            tb.DataFrame(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
         ],
         [
-            DataFrame(),
-            DataTable(),
+            pd.DataFrame(),
+            tb.DataFrame(),
         ],
         [
-            DataFrame(index=range(6)),
-            DataTable.columnless(height=6),
+            pd.DataFrame(index=range(6)),
+            tb.DataFrame.columnless(height=6),
         ],
     ],
 )
-def test_pandas_conversion(df, table):
-    assert table == DataTable.from_pandas(df)
-    assert df.equals(table.to_pandas())
+def test_pandas_conversion(pandas_df, df):
+    assert df == tb.DataFrame.from_pandas(pandas_df)
+    assert pandas_df.equals(df.to_pandas())
 
 
 def test_pandas_conversion_rowless():
     # Polars and Pandas have no concept of List[Nothing]
-    df = DataFrame(dict(x=[], y=[], z=[]))
-    actual = DataTable.from_pandas(df)
+    pandas_df = pd.DataFrame(dict(x=[], y=[], z=[]))
+    actual = tb.DataFrame.from_pandas(pandas_df)
     assert actual.shape == (0, 3)
     assert actual.column_names == ("x", "y", "z")
 
-    table = DataTable(x=[], y=[], z=[])
-    actual = table.to_pandas()
+    df = tb.DataFrame(x=[], y=[], z=[])
+    actual = df.to_pandas()
     assert actual.shape == (0, 3)
     assert tuple(actual.columns) == ("x", "y", "z")

--- a/tests/test_polars_conversion.py
+++ b/tests/test_polars_conversion.py
@@ -1,34 +1,34 @@
+import polars as pl
 import pytest
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
-from tabeline import DataTable
+import tabeline as tb
 
 
 @pytest.mark.parametrize(
-    ["df", "table"],
+    ["polars_df", "df"],
     [
         [
-            DataFrame(dict(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True])),
-            DataTable(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
+            pl.DataFrame(dict(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True])),
+            tb.DataFrame(x=[0, 0, 1], y=["a", "b", "b"], z=[True, False, True]),
         ],
         [
-            DataFrame(dict(x=[], y=[], z=[])),
-            DataTable(x=[], y=[], z=[]),
+            pl.DataFrame(dict(x=[], y=[], z=[])),
+            tb.DataFrame(x=[], y=[], z=[]),
         ],
         [
-            DataFrame(),
-            DataTable(),
+            pl.DataFrame(),
+            tb.DataFrame(),
         ],
     ],
 )
-def test_polars_conversion(df, table):
-    assert table == DataTable.from_polars(df)
-    assert_frame_equal(df, table.to_polars())
+def test_polars_conversion(polars_df, df):
+    assert df == tb.DataFrame.from_polars(polars_df)
+    assert_frame_equal(polars_df, df.to_polars())
 
 
 def test_to_polars_columnless():
-    table = DataTable.columnless(height=6)
-    actual = table.to_polars()
-    expected = DataFrame()
+    df = tb.DataFrame.columnless(height=6)
+    actual = df.to_polars()
+    expected = pl.DataFrame()
     assert_frame_equal(actual, expected)

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,66 +1,66 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import NonexistentColumn, RenameExisting
 
 swappers = [{"x": "y", "y": "x"}, {"y": "x", "x": "y"}]
 
 
 def test_rename():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.rename(yy="y")
-    expected = DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.rename(yy="y")
+    expected = DataFrame(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
     assert actual == expected
 
 
 def test_rename_multiple():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.rename(xx="x", yy="y")
-    expected = DataTable(xx=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.rename(xx="x", yy="y")
+    expected = DataFrame(xx=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
     assert actual == expected
 
 
 def test_rename_multiple_different_order():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.rename(yy="y", xx="x")
-    expected = DataTable(xx=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.rename(yy="y", xx="x")
+    expected = DataFrame(xx=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.rename(**swappers)
-    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.rename(**swappers)
+    expected = DataFrame(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"])
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_into_group(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
-    actual = table.rename(**swappers)
-    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x")
+    actual = df.rename(**swappers)
+    expected = DataFrame(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y")
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_within_group(swappers):
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
-    actual = table.rename(**swappers)
-    expected = DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y", "x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
+    actual = df.rename(**swappers)
+    expected = DataFrame(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"]).group_by("y", "x")
     assert actual == expected
 
 
 @pytest.mark.parametrize("swappers", swappers)
 def test_rename_swap_between_group_levels(swappers):
-    table = (
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = (
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y")
     )
-    actual = table.rename(**swappers)
+    actual = df.rename(**swappers)
     expected = (
-        DataTable(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"])
+        DataFrame(y=[0, 0, 1], x=[True, False, True], z=["a", "b", "c"])
         .group_by("y")
         .group_by("x")
     )
@@ -68,32 +68,32 @@ def test_rename_swap_between_group_levels(swappers):
 
 
 def test_rename_earlier_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
-    actual = table.rename(xx="x")
-    expected = DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by(
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
+    actual = df.rename(xx="x")
+    expected = DataFrame(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by(
         "xx", "y"
     )
     assert actual == expected
 
 
 def test_rename_later_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
-    actual = table.rename(yy="y")
-    expected = DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group_by(
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
+    actual = df.rename(yy="y")
+    expected = DataFrame(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"]).group_by(
         "x", "yy"
     )
     assert actual == expected
 
 
 def test_rename_earlier_group_level():
-    table = (
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = (
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y")
     )
-    actual = table.rename(xx="x")
+    actual = df.rename(xx="x")
     expected = (
-        DataTable(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+        DataFrame(xx=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("xx")
         .group_by("y")
     )
@@ -101,14 +101,14 @@ def test_rename_earlier_group_level():
 
 
 def test_rename_later_group_level():
-    table = (
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = (
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y")
     )
-    actual = table.rename(yy="y")
+    actual = df.rename(yy="y")
     expected = (
-        DataTable(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
+        DataFrame(x=[0, 0, 1], yy=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("yy")
     )
@@ -116,53 +116,53 @@ def test_rename_later_group_level():
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable(x=[0, 0, 1]),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
-        DataTable().group_by(),
-        DataTable(x=[0, 0, 1]).group_by("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+        DataFrame(),
+        DataFrame(x=[0, 0, 1]),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
+        DataFrame().group_by(),
+        DataFrame(x=[0, 0, 1]).group_by("x"),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y"),
     ],
 )
-def test_noop_rename(table: DataTable):
-    actual = table.rename()
-    assert actual == table
+def test_noop_rename(df: DataFrame):
+    actual = df.rename()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
     "columns", [{"x": "x"}, {"y": "y"}, {"x": "x", "y": "y"}, {"y": "y", "x": "x"}]
 )
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x"),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y"),
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y"),
     ],
 )
-def test_rename_self(columns, table):
-    actual = table.rename(**columns)
-    assert actual == table
+def test_rename_self(columns, df):
+    actual = df.rename(**columns)
+    assert actual == df
 
 
 def test_rename_nonexistent():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
 
     with pytest.raises(NonexistentColumn):
-        _ = table.rename(aa="a")
+        _ = df.rename(aa="a")
 
 
 def test_rename_existing():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
 
     with pytest.raises(RenameExisting):
-        _ = table.rename(x="y")
+        _ = df.rename(x="y")

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,13 +1,13 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import NonexistentColumn
 
 
 def test_select():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    actual = table.select("x", "z")
-    expected = DataTable(x=[0, 0, 1], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    actual = df.select("x", "z")
+    expected = DataFrame(x=[0, 0, 1], z=["a", "b", "c"])
     assert actual == expected
 
 
@@ -32,9 +32,9 @@ test_columns = {
     ],
 )
 def test_select_columns(input_columns: list[str], selectors: list[str]):
-    table = DataTable(**{name: test_columns[name] for name in input_columns})
-    actual = table.select(*selectors)
-    expected = DataTable(**{name: test_columns[name] for name in selectors})
+    df = DataFrame(**{name: test_columns[name] for name in input_columns})
+    actual = df.select(*selectors)
+    expected = DataFrame(**{name: test_columns[name] for name in selectors})
     assert actual == expected
 
 
@@ -47,9 +47,9 @@ def test_select_columns(input_columns: list[str], selectors: list[str]):
     ],
 )
 def test_select_no_columns(input_columns):
-    table = DataTable(**{name: test_columns[name] for name in input_columns})
-    actual = table.select()
-    expected = DataTable.columnless(height=table.height)
+    df = DataFrame(**{name: test_columns[name] for name in input_columns})
+    actual = df.select()
+    expected = DataFrame.columnless(height=df.height)
     assert actual == expected
 
 
@@ -83,44 +83,44 @@ def test_select_columns_grouped(
     selectors: list[str],
     expected_columns: list[str],
 ):
-    table = DataTable(**{name: test_columns[name] for name in input_columns})
+    df = DataFrame(**{name: test_columns[name] for name in input_columns})
     for level in groups:
-        table = table.group_by(*level)
-    actual = table.select(*selectors)
-    expected = DataTable(**{name: test_columns[name] for name in expected_columns})
+        df = df.group_by(*level)
+    actual = df.select(*selectors)
+    expected = DataFrame(**{name: test_columns[name] for name in expected_columns})
     for level in groups:
         expected = expected.group_by(*level)
     assert actual == expected
 
 
 def test_select_nonexistent_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
 
     with pytest.raises(NonexistentColumn):
-        _ = table.select("x", "a")
+        _ = df.select("x", "a")
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_select_empty(table):
-    actual = table.select()
-    assert actual == table
+def test_select_empty(df):
+    actual = df.select()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_select_columnless(table):
-    actual = table.select()
-    assert actual == table
+def test_select_columnless(df):
+    actual = df.select()
+    assert actual == df

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -1,71 +1,71 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import IndexOutOfRange
 
 
 def test_slice():
-    table = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    df = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
 
-    expected = DataTable(x=[1, 3], y=[True, True], z=[3.5, 6.7])
+    expected = DataFrame(x=[1, 3], y=[True, True], z=[3.5, 6.7])
 
-    actual = table.slice0([0, 2])
+    actual = df.slice0([0, 2])
     assert actual == expected
 
-    actual = table.slice1([1, 3])
+    actual = df.slice1([1, 3])
     assert actual == expected
 
 
 def test_slice_out_of_bounds():
-    table = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    df = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
 
     # General Exception because who know what will come out of Polars
     with pytest.raises(Exception):
-        _ = table.slice0([2, 4])
+        _ = df.slice0([2, 4])
 
     with pytest.raises(Exception):
-        _ = table.slice1([0, 2])
+        _ = df.slice1([0, 2])
 
 
 def test_slice_groups():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
+    df = DataFrame(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[2, 1, 2, 1], y=[6.7, 8.9, -1.1, 4.5]).group_by("x")
+    expected = DataFrame(x=[2, 1, 2, 1], y=[6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    actual = table.slice0([1, 2])
+    actual = df.slice0([1, 2])
     assert actual == expected
 
-    actual = table.slice1([2, 3])
+    actual = df.slice1([2, 3])
     assert actual == expected
 
 
 def test_slice_one_index():
-    table = DataTable(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
+    df = DataFrame(x=[1, 2, 3, 4], y=[True, False, True, True], z=[3.5, 2.2, 6.7, 8.9])
 
-    expected = DataTable(x=[1], y=[True], z=[3.5])
+    expected = DataFrame(x=[1], y=[True], z=[3.5])
 
-    actual = table.slice0([0])
+    actual = df.slice0([0])
     assert actual == expected
 
-    actual = table.slice1([1])
+    actual = df.slice1([1])
     assert actual == expected
 
 
 def test_slice_groups_one_index():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
+    df = DataFrame(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[2, 1], y=[6.7, 8.9]).group_by("x")
+    expected = DataFrame(x=[2, 1], y=[6.7, 8.9]).group_by("x")
 
-    actual = table.slice0([1])
+    actual = df.slice0([1])
     assert actual == expected
 
-    actual = table.slice1([2])
+    actual = df.slice1([2])
     assert actual == expected
 
 
 def test_slice_groups_multiple_columns_one_index():
-    table = (
-        DataTable(
+    df = (
+        DataFrame(
             x=[1, 2, 2, 1, 2, 1, 1, 2],
             y=["a", "a", "a", "a", "b", "b", "b", "b"],
             z=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5, 4.3, 7.7],
@@ -75,45 +75,45 @@ def test_slice_groups_multiple_columns_one_index():
     )
 
     expected = (
-        DataTable(x=[2, 1, 1, 2], y=["a", "a", "b", "b"], z=[6.7, 8.9, 4.3, 7.7])
+        DataFrame(x=[2, 1, 1, 2], y=["a", "a", "b", "b"], z=[6.7, 8.9, 4.3, 7.7])
         .group_by("x")
         .group_by("y")
     )
 
-    actual = table.slice0([1])
+    actual = df.slice0([1])
     assert actual == expected
 
-    actual = table.slice1([2])
+    actual = df.slice1([2])
     assert actual == expected
 
 
 def test_slice_to_nothing():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5])
+    df = DataFrame(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5])
 
-    expected = DataTable(x=[], y=[])
+    expected = DataFrame(x=[], y=[])
 
-    actual = table.slice0([])
+    actual = df.slice0([])
     assert actual == expected
 
-    actual = table.slice1([])
+    actual = df.slice1([])
     assert actual == expected
 
 
 def test_slice_groups_to_nothing():
-    table = DataTable(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
+    df = DataFrame(x=[1, 2, 2, 1, 2, 1], y=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5]).group_by("x")
 
-    expected = DataTable(x=[], y=[]).group_by("x")
+    expected = DataFrame(x=[], y=[]).group_by("x")
 
-    actual = table.slice0([])
+    actual = df.slice0([])
     assert actual == expected
 
-    actual = table.slice1([])
+    actual = df.slice1([])
     assert actual == expected
 
 
 def test_slice_multiple_groups_to_nothing():
-    table = (
-        DataTable(
+    df = (
+        DataFrame(
             x=[1, 2, 2, 1, 2, 1, 1, 2],
             y=["a", "a", "a", "a", "b", "b", "b", "b"],
             z=[3.5, 2.2, 6.7, 8.9, -1.1, 4.5, 4.3, 7.7],
@@ -122,128 +122,128 @@ def test_slice_multiple_groups_to_nothing():
         .group_by("y")
     )
 
-    expected = DataTable(x=[], y=[], z=[]).group_by("x").group_by("y")
+    expected = DataFrame(x=[], y=[], z=[]).group_by("x").group_by("y")
 
-    actual = table.slice0([])
+    actual = df.slice0([])
     assert actual == expected
 
-    actual = table.slice1([])
+    actual = df.slice1([])
     assert actual == expected
 
 
 def test_slice_only_one_out_of_bounds():
-    table = DataTable(x=[1, 2, 2, 1, 2], y=[3.5, 2.2, 6.7, 8.9, -1.1]).group_by("x")
+    df = DataFrame(x=[1, 2, 2, 1, 2], y=[3.5, 2.2, 6.7, 8.9, -1.1]).group_by("x")
 
     # General Exception because who know what will come out of Polars
     with pytest.raises(Exception):
-        _ = table.slice0([1, 2])
+        _ = df.slice0([1, 2])
 
     with pytest.raises(Exception):
-        _ = table.slice1([2, 3])
+        _ = df.slice1([2, 3])
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_slice_empty(table):
-    actual = table.slice0([])
-    assert actual == table
+def test_slice_empty(df):
+    actual = df.slice0([])
+    assert actual == df
 
-    actual = table.slice1([])
-    assert actual == table
+    actual = df.slice1([])
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_slice_empty_out_of_bounds(table):
-    table = DataTable()
+def test_slice_empty_out_of_bounds(df):
+    df = DataFrame()
 
     # General Exception because who know what will come out of Polars
     with pytest.raises(Exception):
-        _ = table.slice0([0])
+        _ = df.slice0([0])
 
     with pytest.raises(Exception):
-        _ = table.slice1([1])
+        _ = df.slice1([1])
 
 
 @pytest.mark.parametrize(
-    ["table", "expected"],
+    ["df", "expected"],
     [
-        [DataTable.columnless(height=6), DataTable.columnless(height=3)],
-        [DataTable.columnless(height=6).group_by(), DataTable.columnless(height=3).group_by()],
+        [DataFrame.columnless(height=6), DataFrame.columnless(height=3)],
+        [DataFrame.columnless(height=6).group_by(), DataFrame.columnless(height=3).group_by()],
         [
-            DataTable.columnless(height=6).group_by().group_by(),
-            DataTable.columnless(height=3).group_by().group_by(),
+            DataFrame.columnless(height=6).group_by().group_by(),
+            DataFrame.columnless(height=3).group_by().group_by(),
         ],
     ],
 )
-def test_slice_columnless(table, expected):
-    actual = table.slice0([0, 1, 4])
+def test_slice_columnless(df, expected):
+    actual = df.slice0([0, 1, 4])
     assert actual == expected
 
-    actual = table.slice1([1, 2, 5])
+    actual = df.slice1([1, 2, 5])
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=4),
-        DataTable.columnless(height=4).group_by(),
-        DataTable.columnless(height=4).group_by().group_by(),
+        DataFrame.columnless(height=4),
+        DataFrame.columnless(height=4).group_by(),
+        DataFrame.columnless(height=4).group_by().group_by(),
     ],
 )
-def test_slice_columnless_out_of_bounds(table):
+def test_slice_columnless_out_of_bounds(df):
     with pytest.raises(IndexOutOfRange):
-        _ = table.slice0([2, 4])
+        _ = df.slice0([2, 4])
 
     with pytest.raises(IndexOutOfRange):
-        _ = table.slice1([0, 2])
+        _ = df.slice1([0, 2])
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group_by(),
-        DataTable(x=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[]).group_by(),
+        DataFrame(x=[]).group_by().group_by(),
     ],
 )
-def test_slice_rowless(table):
-    table = DataTable(x=[], y=[], z=[])
+def test_slice_rowless(df):
+    df = DataFrame(x=[], y=[], z=[])
 
-    actual = table.slice0([])
-    assert actual == table
+    actual = df.slice0([])
+    assert actual == df
 
-    actual = table.slice1([])
-    assert actual == table
+    actual = df.slice1([])
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group_by(),
-        DataTable(x=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[]).group_by(),
+        DataFrame(x=[]).group_by().group_by(),
     ],
 )
-def test_slice_rowless_out_of_bounds(table):
-    table = DataTable(x=[], y=[], z=[])
+def test_slice_rowless_out_of_bounds(df):
+    df = DataFrame(x=[], y=[], z=[])
 
     # General Exception because who know what will come out of Polars
     with pytest.raises(Exception):
-        _ = table.slice0([0])
+        _ = df.slice0([0])
 
     with pytest.raises(Exception):
-        _ = table.slice1([1])
+        _ = df.slice1([1])

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,93 +1,89 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_sort():
-    table = DataTable(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
-    actual = table.sort("x")
-    expected = DataTable(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 3.4, 2.1, 0.0], z=[2, 1, 4, 5, 3])
+    df = DataFrame(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
+    actual = df.sort("x")
+    expected = DataFrame(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 3.4, 2.1, 0.0], z=[2, 1, 4, 5, 3])
     assert actual == expected
 
 
 def test_sort_two():
-    table = DataTable(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
-    actual = table.sort("x", "y")
-    expected = DataTable(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 2.1, 3.4, 0.0], z=[2, 1, 5, 4, 3])
+    df = DataFrame(x=[1, 0, 2, 1, 1], y=[2.1, 1.0, 0.0, 3.4, 2.1], z=[1, 2, 3, 4, 5])
+    actual = df.sort("x", "y")
+    expected = DataFrame(x=[0, 1, 1, 1, 2], y=[1.0, 2.1, 2.1, 3.4, 0.0], z=[2, 1, 5, 4, 3])
     assert actual == expected
 
 
 def test_sort_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by(
-        "x"
-    )
-    actual = table.sort("y")
-    expected = DataTable(
+    df = DataFrame(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by("x")
+    actual = df.sort("y")
+    expected = DataFrame(
         x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 5, 2, 3, 0, 4]
     ).group_by("x")
     assert actual == expected
 
 
 def test_sort_two_grouped():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by(
-        "x"
-    )
-    actual = table.sort("y", "z")
-    expected = DataTable(
+    df = DataFrame(x=[2, 2, 1, 1, 2, 2], y=[3, 4, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by("x")
+    actual = df.sort("y", "z")
+    expected = DataFrame(
         x=[2, 2, 1, 1, 2, 2], y=[1, 3, 1, 3, 3, 4], z=[1, 0, 2, 3, 5, 4]
     ).group_by("x")
     assert actual == expected
 
 
 def test_sort_grouped_two():
-    table = DataTable(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by(
+    df = DataFrame(x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[5, 4, 3, 2, 1, 0]).group_by(
         "x", "y"
     )
-    actual = table.sort("z")
-    expected = DataTable(
+    actual = df.sort("z")
+    expected = DataFrame(
         x=[2, 2, 1, 1, 2, 2], y=[3, 3, 3, 1, 1, 3], z=[0, 4, 3, 2, 1, 5]
     ).group_by("x", "y")
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_sort_empty(table):
-    actual = table.sort()
-    assert actual == table
+def test_sort_empty(df):
+    actual = df.sort()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_sort_columnless(table):
-    actual = table.sort()
-    assert actual == table
+def test_sort_columnless(df):
+    actual = df.sort()
+    assert actual == df
 
 
 @pytest.mark.parametrize("columns", [[], ["z"], ["z", "y"], ["y", "z"]])
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[], z=[]).group_by(),
-        DataTable(x=[], y=[], z=[]).group_by().group_by(),
-        DataTable(x=[], y=[], z=[]).group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("x", "w"),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[], z=[]).group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("x", "w"),
     ],
 )
-def test_sort_rowless(columns, table):
-    actual = table.sort()
-    assert actual == table
+def test_sort_rowless(columns, df):
+    actual = df.sort()
+    assert actual == df

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -1,10 +1,10 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_spread():
-    table = DataTable(
+    df = DataFrame(
         grades=[0, 0, 1, 1, 2, 2], sex=["M", "F", "M", "F", "M", "F"], count=[8, 9, 9, 10, 6, 9]
     )
-    actual = table.group_by("sex").spread("grades", "count")
-    expected = DataTable.from_dict({"sex": ["M", "F"], "0": [8, 9], "1": [9, 10], "2": [6, 9]})
+    actual = df.group_by("sex").spread("grades", "count")
+    expected = DataFrame.from_dict({"sex": ["M", "F"], "0": [8, 9], "1": [9, 10], "2": [6, 9]})
     assert actual == expected

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -1,39 +1,39 @@
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_str():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    _ = str(table)
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    _ = str(df)
 
 
 def test_str_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
-    _ = str(table)
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
+    _ = str(df)
 
 
 def test_str_multiple_level_grouped():
-    table = (
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = (
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y")
     )
-    _ = str(table)
+    _ = str(df)
 
 
 def test_repr():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
-    _ = str(table)
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    _ = str(df)
 
 
 def test_repr_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
-    _ = str(table)
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"]).group_by("x", "y")
+    _ = str(df)
 
 
 def test_repr_multiple_level_grouped():
-    table = (
-        DataTable(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
+    df = (
+        DataFrame(x=[0, 0, 1], y=[True, False, True], z=["a", "b", "c"])
         .group_by("x")
         .group_by("y")
     )
-    _ = str(table)
+    _ = str(df)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,73 +1,73 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_summarize():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group_by("x").summarize(size="n()", max_y="max(y)")
-    expected = DataTable(x=[0, 1], size=[2, 2], max_y=[2, 4])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.group_by("x").summarize(size="n()", max_y="max(y)")
+    expected = DataFrame(x=[0, 1], size=[2, 2], max_y=[2, 4])
     assert actual == expected
 
 
 def test_summarize_back_reference():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group_by("x").summarize(max_y="max(y)", inverted="-max_y")
-    expected = DataTable(x=[0, 1], max_y=[2, 4], inverted=[-2, -4])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.group_by("x").summarize(max_y="max(y)", inverted="-max_y")
+    expected = DataFrame(x=[0, 1], max_y=[2, 4], inverted=[-2, -4])
     assert actual == expected
 
 
 def test_summarize_original_and_back_reference():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 5])
-    actual = table.group_by("x").summarize(max_y="max(y)", range="max_y-min(y)")
-    expected = DataTable(x=[0, 1], max_y=[2, 5], range=[1, 2])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 5])
+    actual = df.group_by("x").summarize(max_y="max(y)", range="max_y-min(y)")
+    expected = DataFrame(x=[0, 1], max_y=[2, 5], range=[1, 2])
     assert actual == expected
 
 
 def test_literal_in_summarize():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group_by("x").summarize(new="1")
-    expected = DataTable(x=[0, 1], new=[1, 1])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.group_by("x").summarize(new="1")
+    expected = DataFrame(x=[0, 1], new=[1, 1])
     assert actual == expected
 
 
 def test_empty_summarize():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
-    actual = table.group_by("x").summarize()
-    expected = DataTable(x=[0, 1])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 4])
+    actual = df.group_by("x").summarize()
+    expected = DataFrame(x=[0, 1])
     assert actual == expected
 
 
 def test_empty_summarize_on_two_groups():
-    table = DataTable(x=[0, 0, 1, 1, 0], y=[1, 2, 2, 2, 2], z=[1, 2, 3, 4, 5])
-    actual = table.group_by("x", "y").summarize()
-    expected = DataTable(x=[0, 0, 1], y=[1, 2, 2])
+    df = DataFrame(x=[0, 0, 1, 1, 0], y=[1, 2, 2, 2, 2], z=[1, 2, 3, 4, 5])
+    actual = df.group_by("x", "y").summarize()
+    expected = DataFrame(x=[0, 0, 1], y=[1, 2, 2])
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_summarize_empty(table):
-    actual = table.summarize()
-    expected = table.ungroup()
+def test_summarize_empty(df):
+    actual = df.summarize()
+    expected = df.ungroup()
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_summarize_columnless(table):
-    actual = table.summarize()
-    expected = table.slice0([0]).ungroup()
+def test_summarize_columnless(df):
+    actual = df.summarize()
+    expected = df.slice0([0]).ungroup()
     assert actual == expected
 
 
@@ -80,7 +80,7 @@ def test_summarize_columnless(table):
     ],
 )
 def test_summarize_rowless(expressions):
-    table = DataTable(w=[], x=[], y=[], z=[])
-    actual = table.group_by("x", "y").summarize(**expressions)
-    expected = DataTable(x=[], y=[], a=[], b=[])
+    df = DataFrame(w=[], x=[], y=[], z=[])
+    actual = df.group_by("x", "y").summarize(**expressions)
+    expected = DataFrame(x=[], y=[], a=[], b=[])
     assert actual == expected

--- a/tests/test_transmute.py
+++ b/tests/test_transmute.py
@@ -1,106 +1,106 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import GroupColumn
 
 
 def test_transmute():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True])
-    actual = table.transmute(z="x + 1")
-    expected = DataTable(z=[1, 1, 2])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True])
+    actual = df.transmute(z="x + 1")
+    expected = DataFrame(z=[1, 1, 2])
     assert actual == expected
 
 
 def test_transmute_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
-    actual = table.transmute(zz="z + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[4, 3, 5]).group_by("y", "x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
+    actual = df.transmute(zz="z + 1")
+    expected = DataFrame(y=[True, False, True], x=[0, 0, 1], zz=[4, 3, 5]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_referencing_group():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
-    actual = table.transmute(zz="x + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], zz=[1, 1, 2]).group_by("y", "x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4]).group_by("y", "x")
+    actual = df.transmute(zz="x + 1")
+    expected = DataFrame(y=[True, False, True], x=[0, 0, 1], zz=[1, 1, 2]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_overwrite():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True])
-    actual = table.transmute(x="x + 1")
-    expected = DataTable(x=[1, 1, 2])
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True])
+    actual = df.transmute(x="x + 1")
+    expected = DataFrame(x=[1, 1, 2])
     assert actual == expected
 
 
 def test_transmute_overwrite_grouped():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
         "y", "x"
     )
-    actual = table.transmute(z="z + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[4, 3, 5]).group_by("y", "x")
+    actual = df.transmute(z="z + 1")
+    expected = DataFrame(y=[True, False, True], x=[0, 0, 1], z=[4, 3, 5]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_overwrite_referencing_group():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True], z=[3, 2, 4], a=[2.3, 4.5, 6.7]).group_by(
         "y", "x"
     )
-    actual = table.transmute(z="x + 1")
-    expected = DataTable(y=[True, False, True], x=[0, 0, 1], z=[1, 1, 2]).group_by("y", "x")
+    actual = df.transmute(z="x + 1")
+    expected = DataFrame(y=[True, False, True], x=[0, 0, 1], z=[1, 1, 2]).group_by("y", "x")
     assert actual == expected
 
 
 def test_transmute_reference_previous_mutator():
-    table = DataTable(x=[0, 0, 1])
-    actual = table.transmute(y="x + 1", z="2*y")
-    expected = DataTable(y=[1, 1, 2], z=[2, 2, 4])
+    df = DataFrame(x=[0, 0, 1])
+    actual = df.transmute(y="x + 1", z="2*y")
+    expected = DataFrame(y=[1, 1, 2], z=[2, 2, 4])
     assert actual == expected
 
 
 def test_transmute_reference_previous_mutator_grouped():
-    table = DataTable(x=[0, 0, 1], a=[2.3, 4.5, 6.7]).group_by("x")
-    actual = table.transmute(y="x + 1", z="2*y")
-    expected = DataTable(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4]).group_by("x")
+    df = DataFrame(x=[0, 0, 1], a=[2.3, 4.5, 6.7]).group_by("x")
+    actual = df.transmute(y="x + 1", z="2*y")
+    expected = DataFrame(x=[0, 0, 1], y=[1, 1, 2], z=[2, 2, 4]).group_by("x")
     assert actual == expected
 
 
 def test_transmute_broadcast_scalar():
-    table = DataTable(x=[0, 0, 1])
-    actual = table.transmute(max_x="max(x)")
-    expected = DataTable(max_x=[1, 1, 1])
+    df = DataFrame(x=[0, 0, 1])
+    actual = df.transmute(max_x="max(x)")
+    expected = DataFrame(max_x=[1, 1, 1])
     assert actual == expected
 
 
 def test_transmute_group_column():
-    table = DataTable(x=[0, 0, 1], y=[True, False, True]).group_by("x")
+    df = DataFrame(x=[0, 0, 1], y=[True, False, True]).group_by("x")
     with pytest.raises(GroupColumn):
-        _ = table.transmute(x="x+1")
+        _ = df.transmute(x="x+1")
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_mutate_empty(table):
-    actual = table.transmute()
-    assert actual == table
+def test_mutate_empty(df):
+    actual = df.transmute()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_mutate_columnless(table):
-    actual = table.transmute()
-    assert actual == table
+def test_mutate_columnless(df):
+    actual = df.transmute()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
@@ -112,17 +112,17 @@ def test_mutate_columnless(table):
     ],
 )
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(y=[], z=[]),
-        DataTable(y=[], z=[]).group_by(),
-        DataTable(y=[], z=[]).group_by().group_by(),
-        DataTable(x=[], y=[], z=[]).group_by("x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("w", "x"),
-        DataTable(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
+        DataFrame(y=[], z=[]),
+        DataFrame(y=[], z=[]).group_by(),
+        DataFrame(y=[], z=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]).group_by("x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("w", "x"),
+        DataFrame(w=[], x=[], y=[], z=[]).group_by("w").group_by("x"),
     ],
 )
-def test_transmute_rowless(expression, table):
-    actual = table.transmute(**expression)
-    expected = table.deselect("z")
+def test_transmute_rowless(expression, df):
+    actual = df.transmute(**expression)
+    expected = df.deselect("z")
     assert actual == expected

--- a/tests/test_ungroup.py
+++ b/tests/test_ungroup.py
@@ -1,44 +1,44 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 from tabeline.exceptions import NoGroups
 
 
 def test_ungroup():
     actual = (
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup()
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup()
     )
-    expected = DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x")
+    expected = DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x")
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by().ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by().ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
         .group_by()
         .group_by()
         .ungroup()
         .ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
         .group_by("x")
         .group_by("y")
         .ungroup()
         .ungroup(),
     ],
 )
-def test_ungroup_completely(table):
-    assert table.group_levels == ()
+def test_ungroup_completely(df):
+    assert df.group_levels == ()
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").group_by("y").ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
         .group_by("x")
         .group_by()
         .group_by("y")
@@ -46,23 +46,23 @@ def test_ungroup_completely(table):
         .ungroup(),
     ],
 )
-def test_ungroup_to_one_level(table):
-    assert table.group_levels == (("x",),)
+def test_ungroup_to_one_level(df):
+    assert df.group_levels == (("x",),)
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
-        DataTable(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x").ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"]).group_by("x", "y").ungroup(),
+        DataFrame(x=[0, 0, 1, 1], y=["a", "b", "b", "b"])
         .group_by("y")
         .group_by("x")
         .ungroup()
         .ungroup(),
     ],
 )
-def test_ungroup_no_groups(table):
+def test_ungroup_no_groups(df):
     with pytest.raises(NoGroups):
-        _ = table.ungroup()
+        _ = df.ungroup()

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -1,57 +1,57 @@
 import pytest
 
-from tabeline import DataTable
+from tabeline import DataFrame
 
 
 def test_unique():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3])
-    actual = table.unique()
-    expected = DataTable(x=[0, 0, 1], y=[1, 2, 3])
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3])
+    actual = df.unique()
+    expected = DataFrame(x=[0, 0, 1], y=[1, 2, 3])
     assert actual == expected
 
 
 def test_unique_grouped():
-    table = DataTable(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
-    actual = table.unique()
-    expected = DataTable(x=[0, 0, 1], y=[1, 2, 3]).group_by("x")
+    df = DataFrame(x=[0, 0, 1, 1], y=[1, 2, 3, 3]).group_by("x")
+    actual = df.unique()
+    expected = DataFrame(x=[0, 0, 1], y=[1, 2, 3]).group_by("x")
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(),
-        DataTable().group_by(),
-        DataTable().group_by().group_by(),
+        DataFrame(),
+        DataFrame().group_by(),
+        DataFrame().group_by().group_by(),
     ],
 )
-def test_unique_empty(table):
-    actual = table.unique()
-    assert actual == table
+def test_unique_empty(df):
+    actual = df.unique()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable(x=[], y=[], z=[]),
-        DataTable(x=[], y=[]).group_by(),
-        DataTable(x=[], y=[]).group_by().group_by(),
+        DataFrame(x=[], y=[], z=[]),
+        DataFrame(x=[], y=[]).group_by(),
+        DataFrame(x=[], y=[]).group_by().group_by(),
     ],
 )
-def test_unique_rowless(table):
-    actual = table.unique()
-    assert actual == table
+def test_unique_rowless(df):
+    actual = df.unique()
+    assert actual == df
 
 
 @pytest.mark.parametrize(
-    "table",
+    "df",
     [
-        DataTable.columnless(height=6),
-        DataTable.columnless(height=6).group_by(),
-        DataTable.columnless(height=6).group_by().group_by(),
+        DataFrame.columnless(height=6),
+        DataFrame.columnless(height=6).group_by(),
+        DataFrame.columnless(height=6).group_by().group_by(),
     ],
 )
-def test_unique_columnless(table):
-    actual = table.unique()
-    expected = table.slice1([1])
+def test_unique_columnless(df):
+    actual = df.unique()
+    expected = df.slice1([1])
     assert actual == expected


### PR DESCRIPTION
This renames the main class from `DataTable` to `DataFrame`. This brings Tabeline closer to Pandas, Polars, and, to a more limited extent, dplyr. I always thought that "data table" was a clearer name than "data frame", but with Pandas and Polars both leaning entirely on "data frame', there is really no hope of swimming against this tide.

`tabeline.DataTable` continues to exist as an alias for backwards compatibilty.