### PR TITLE
Add inverse trigonometry functions

### DIFF
--- a/src/tabeline/_expression/_functions.py
+++ b/src/tabeline/_expression/_functions.py
@@ -32,9 +32,9 @@ built_in_functions: list[Function[Any, Any]] = [
     Function("sin", lambda x: x.sin()),
     Function("cos", lambda x: x.cos()),
     Function("tan", lambda x: x.tan()),
-    # Function("arcsin", lambda x: x.arcsin()),  # Decide on name
-    # Function("arccos", lambda x: x.arccos()),  # Decide on name
-    # Function("arctan", lambda x: x.arctan()),  # Decide on name
+    Function("arcsin", lambda x: x.arcsin()),
+    Function("arccos", lambda x: x.arccos()),
+    Function("arctan", lambda x: x.arctan()),
     Function("floor", lambda x: x.floor()),
     Function("ceil", lambda x: x.ceil()),
     # Numeric -> boolean elementwise

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -23,6 +23,9 @@ one_argument_functions = [
     "sin",
     "cos",
     "tan",
+    "arcsin",
+    "arccos",
+    "arctan",
     "floor",
     "ceil",
     "is_nan",
@@ -52,12 +55,15 @@ one_argument_functions = [
         ["sin", math.sin],
         ["cos", math.cos],
         ["tan", math.tan],
+        ["arcsin", math.asin],
+        ["arccos", math.acos],
+        ["arctan", math.atan],
         ["floor", math.floor],
         ["ceil", math.ceil],
     ],
 )
 def test_single_numeric_argument_against_python(name, function):
-    values = [0.5, 1.0, math.pi]
+    values = [0.5, 1.0, math.pi / 4]
     df = DataFrame(x=values)
     actual = df.transmute(y=f"{name}(x)")
     expected = DataFrame(y=[function(value) for value in values])


### PR DESCRIPTION
These are named `arcsin`, `arccos`, and `arctan`. I think these are the clearest names and also that is what they are called in NumPy and Polars. Python calls them `asin`, `acos`, and `atan`.