### PR TITLE
Add standard .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This should have been included in the initial commit. Hopefully, no Windows users were harmed in the interim.