### PR TITLE
Create automatic releases from tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,14 @@
-name: ci
+name: CI
 
 on:
   pull_request:
   push:
     branches:
       - master
-    tags:
-      - "v*"
 
 env:
   python-version: "3.10"
-  poetry-version: "1.5.1"
+  poetry-version: "1.6.1"
 
 jobs:
   test:
@@ -20,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python ${{ matrix.python-version }}
@@ -45,7 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python
@@ -69,7 +67,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
       - name: Install Python
@@ -85,10 +83,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Poetry
         run: pipx install poetry==${{ env.poetry-version }}
-      - name: Set up Python
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-  #   tags:
-  #     - 'v*'
+    tags:
+      - 'v*'
 
 env:
   python-version: "3.10"
@@ -27,6 +27,9 @@ jobs:
           python-version: ${{ env.python-version }}
       - name: Build release
         run: poetry build
-      - run: ls -al dist
+      - name: Check version
+        run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
       # - name: Upload to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+  #   tags:
+  #     - 'v*'
+
+env:
+  python-version: "3.10"
+  poetry-version: "1.6.1"
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-22.04
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry==${{ env.poetry-version }}
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Build release
+        run: poetry build
+      - run: ls -al dist
+      # - name: Upload to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python-version }}
-      - name: Build release
+      - name: Build release with Poetry
         run: poetry build
-      - name: Check version
+      - name: Check that tag version and Poetry version match
         run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
-      # - name: Upload to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     repository-url: https://test.pypi.org/legacy/
+      - name: Upload distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,3 @@ jobs:
         run: '[[ "v$(poetry version --short)" == "${{ github.ref_name }}" ]]'
       - name: Upload distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,16 +73,7 @@ poetry run mkdocs gh-deploy
 2. Tag
     1. Tag commit with "vX.Y.Z"
     2. Push tag to GitHub
-    3. Check GitHub Actions for tag
-3. Build
-    1. Clear `dist/`
-    2. Run `poetry build`
-    3. Verify that sdist (`.tar.gz`) and bdist (`.whl`) are in `dist/`
-4. Publish
-    1. Run `poetry publish -r test`
-    2. Check [PyPI test server](https://test.pypi.org/project/tabeline/) for good upload
-    3. Run `poetry publish`
-    4. Check [PyPI](https://pypi.org/project/tabeline/) for good upload
-5. Document
+        - `release.yml` will automatically build and publish the tag to [PyPI](https://pypi.org/project/parsita/)
+3. Document
     1. Create [GitHub release](https://github.com/drhagen/tabeline/releases) with name "Tabeline X.Y.Z" and major changes in body
     2. If appropriate, deploy updated docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tabeline"
-version = "0.3.2.dev1"
+version = "0.3.2"
 description = "A data frame and data grammar library"
 authors = ["David Hagen <david@drhagen.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tabeline"
-version = "0.3.2"
+version = "0.3.2.dev1"
 description = "A data frame and data grammar library"
 authors = ["David Hagen <david@drhagen.com>"]
 license = "MIT"
@@ -48,10 +48,7 @@ pandas = ["pandas", "pyarrow"]
 
 
 [tool.pytest.ini_options]
-addopts = [
-    "--strict-config",
-    "--strict-markers",
-]
+addopts = ["--strict-config", "--strict-markers"]
 xfail_strict = true
 filterwarnings = [
     # When running tests, treat warnings as errors (e.g. -Werror).


### PR DESCRIPTION
With 2FA about to be made mandatory on PyPI, this uses the blessed `pypa/gh-action-pypi-publish` GitHub action to publish a new version to PyPI whenever a new tag is pushed.