### PR TITLE
Add support for nulls

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -530,13 +530,13 @@ min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4)", "ghp-imp
 
 [[package]]
 name = "mkdocs-material"
-version = "9.4.5"
+version = "9.4.6"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.4.5-py3-none-any.whl", hash = "sha256:0922e3e34d95dbf3f0c84fc817a233e1cbd5874830c6fd821d525ba90e0ce077"},
-    {file = "mkdocs_material-9.4.5.tar.gz", hash = "sha256:efaa52843a8c64b99bcf5a97cf4ba57d410424828e3087b13c9b3954e8adb5ff"},
+    {file = "mkdocs_material-9.4.6-py3-none-any.whl", hash = "sha256:78802035d5768a78139c84ad7dce0c6493e8f7dc4861727d36ed91d1520a54da"},
+    {file = "mkdocs_material-9.4.6.tar.gz", hash = "sha256:09665e60df7ee9e5ff3a54af173f6d45be718b1ee7dd962bcff3102b81fb0c14"},
 ]
 
 [package.dependencies]
@@ -811,36 +811,40 @@ xlsxwriter = ["xlsxwriter"]
 
 [[package]]
 name = "pyarrow"
-version = "11.0.0"
+version = "13.0.0"
 description = "Python library for Apache Arrow"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyarrow-11.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:40bb42afa1053c35c749befbe72f6429b7b5f45710e85059cdd534553ebcf4f2"},
-    {file = "pyarrow-11.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c28b5f248e08dea3b3e0c828b91945f431f4202f1a9fe84d1012a761324e1ba"},
-    {file = "pyarrow-11.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37bc81f6c9435da3c9c1e767324ac3064ffbe110c4e460660c43e144be4ed85"},
-    {file = "pyarrow-11.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad7c53def8dbbc810282ad308cc46a523ec81e653e60a91c609c2233ae407689"},
-    {file = "pyarrow-11.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:25aa11c443b934078bfd60ed63e4e2d42461682b5ac10f67275ea21e60e6042c"},
-    {file = "pyarrow-11.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:e217d001e6389b20a6759392a5ec49d670757af80101ee6b5f2c8ff0172e02ca"},
-    {file = "pyarrow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad42bb24fc44c48f74f0d8c72a9af16ba9a01a2ccda5739a517aa860fa7e3d56"},
-    {file = "pyarrow-11.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d942c690ff24a08b07cb3df818f542a90e4d359381fbff71b8f2aea5bf58841"},
-    {file = "pyarrow-11.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f010ce497ca1b0f17a8243df3048055c0d18dcadbcc70895d5baf8921f753de5"},
-    {file = "pyarrow-11.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:2f51dc7ca940fdf17893227edb46b6784d37522ce08d21afc56466898cb213b2"},
-    {file = "pyarrow-11.0.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:1cbcfcbb0e74b4d94f0b7dde447b835a01bc1d16510edb8bb7d6224b9bf5bafc"},
-    {file = "pyarrow-11.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaee8f79d2a120bf3e032d6d64ad20b3af6f56241b0ffc38d201aebfee879d00"},
-    {file = "pyarrow-11.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:410624da0708c37e6a27eba321a72f29d277091c8f8d23f72c92bada4092eb5e"},
-    {file = "pyarrow-11.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2d53ba72917fdb71e3584ffc23ee4fcc487218f8ff29dd6df3a34c5c48fe8c06"},
-    {file = "pyarrow-11.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f12932e5a6feb5c58192209af1d2607d488cb1d404fbc038ac12ada60327fa34"},
-    {file = "pyarrow-11.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:41a1451dd895c0b2964b83d91019e46f15b5564c7ecd5dcb812dadd3f05acc97"},
-    {file = "pyarrow-11.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:becc2344be80e5dce4e1b80b7c650d2fc2061b9eb339045035a1baa34d5b8f1c"},
-    {file = "pyarrow-11.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f40be0d7381112a398b93c45a7e69f60261e7b0269cc324e9f739ce272f4f70"},
-    {file = "pyarrow-11.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:362a7c881b32dc6b0eccf83411a97acba2774c10edcec715ccaab5ebf3bb0835"},
-    {file = "pyarrow-11.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:ccbf29a0dadfcdd97632b4f7cca20a966bb552853ba254e874c66934931b9841"},
-    {file = "pyarrow-11.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e99be85973592051e46412accea31828da324531a060bd4585046a74ba45854"},
-    {file = "pyarrow-11.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69309be84dcc36422574d19c7d3a30a7ea43804f12552356d1ab2a82a713c418"},
-    {file = "pyarrow-11.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da93340fbf6f4e2a62815064383605b7ffa3e9eeb320ec839995b1660d69f89b"},
-    {file = "pyarrow-11.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:caad867121f182d0d3e1a0d36f197df604655d0b466f1bc9bafa903aa95083e4"},
-    {file = "pyarrow-11.0.0.tar.gz", hash = "sha256:5461c57dbdb211a632a48facb9b39bbeb8a7905ec95d768078525283caef5f6d"},
+    {file = "pyarrow-13.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:1afcc2c33f31f6fb25c92d50a86b7a9f076d38acbcb6f9e74349636109550148"},
+    {file = "pyarrow-13.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:70fa38cdc66b2fc1349a082987f2b499d51d072faaa6b600f71931150de2e0e3"},
+    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd57b13a6466822498238877892a9b287b0a58c2e81e4bdb0b596dbb151cbb73"},
+    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8ce69f7bf01de2e2764e14df45b8404fc6f1a5ed9871e8e08a12169f87b7a26"},
+    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:588f0d2da6cf1b1680974d63be09a6530fd1bd825dc87f76e162404779a157dc"},
+    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6241afd72b628787b4abea39e238e3ff9f34165273fad306c7acf780dd850956"},
+    {file = "pyarrow-13.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:fda7857e35993673fcda603c07d43889fca60a5b254052a462653f8656c64f44"},
+    {file = "pyarrow-13.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:aac0ae0146a9bfa5e12d87dda89d9ef7c57a96210b899459fc2f785303dcbb67"},
+    {file = "pyarrow-13.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d7759994217c86c161c6a8060509cfdf782b952163569606bb373828afdd82e8"},
+    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:868a073fd0ff6468ae7d869b5fc1f54de5c4255b37f44fb890385eb68b68f95d"},
+    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51be67e29f3cfcde263a113c28e96aa04362ed8229cb7c6e5f5c719003659d33"},
+    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d1b4e7176443d12610874bb84d0060bf080f000ea9ed7c84b2801df851320295"},
+    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:69b6f9a089d116a82c3ed819eea8fe67dae6105f0d81eaf0fdd5e60d0c6e0944"},
+    {file = "pyarrow-13.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:ab1268db81aeb241200e321e220e7cd769762f386f92f61b898352dd27e402ce"},
+    {file = "pyarrow-13.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:ee7490f0f3f16a6c38f8c680949551053c8194e68de5046e6c288e396dccee80"},
+    {file = "pyarrow-13.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3ad79455c197a36eefbd90ad4aa832bece7f830a64396c15c61a0985e337287"},
+    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68fcd2dc1b7d9310b29a15949cdd0cb9bc34b6de767aff979ebf546020bf0ba0"},
+    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc6fd330fd574c51d10638e63c0d00ab456498fc804c9d01f2a61b9264f2c5b2"},
+    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:e66442e084979a97bb66939e18f7b8709e4ac5f887e636aba29486ffbf373763"},
+    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:0f6eff839a9e40e9c5610d3ff8c5bdd2f10303408312caf4c8003285d0b49565"},
+    {file = "pyarrow-13.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b30a27f1cddf5c6efcb67e598d7823a1e253d743d92ac32ec1eb4b6a1417867"},
+    {file = "pyarrow-13.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:09552dad5cf3de2dc0aba1c7c4b470754c69bd821f5faafc3d774bedc3b04bb7"},
+    {file = "pyarrow-13.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3896ae6c205d73ad192d2fc1489cd0edfab9f12867c85b4c277af4d37383c18c"},
+    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6647444b21cb5e68b593b970b2a9a07748dd74ea457c7dadaa15fd469c48ada1"},
+    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47663efc9c395e31d09c6aacfa860f4473815ad6804311c5433f7085415d62a7"},
+    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:b9ba6b6d34bd2563345488cf444510588ea42ad5613df3b3509f48eb80250afd"},
+    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:d00d374a5625beeb448a7fa23060df79adb596074beb3ddc1838adb647b6ef09"},
+    {file = "pyarrow-13.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:c51afd87c35c8331b56f796eff954b9c7f8d4b7fef5903daf4e05fcf017d23a8"},
+    {file = "pyarrow-13.0.0.tar.gz", hash = "sha256:83333726e83ed44b0ac94d8d7a21bbdee4a05029c3b1e8db58a863eec8fd8a33"},
 ]
 
 [package.dependencies]
@@ -1308,4 +1312,4 @@ pandas = ["pandas", "pyarrow"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6f87d9893ee50cca958fcbd0d96656e8a2d28c2490ee6acd66abb848604e034d"
+content-hash = "aa586279aecf12244bc89870c40a815d510543b8f5ac0dc78bcb26c252b048d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ numpy = "^1.24"
 parsita = "^2.0"
 typing_extensions = "^4.3"
 pandas = { version = "^1.4", optional = true }
-pyarrow = { version = "^11.0", optional = true }
+pyarrow = { version = "^13.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 nox_poetry = "^1.0.2"
 
 # Converters
-pyarrow = "^11.0.0"
+pyarrow = "^13.0"
 pandas = "^1.4"
 
 # Test
@@ -64,6 +64,7 @@ exclude_lines = [
     "pragma: no cover",
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
+    "@overload",
 ]
 
 [tool.coverage.paths]

--- a/src/tabeline/__init__.py
+++ b/src/tabeline/__init__.py
@@ -1,6 +1,7 @@
 from ._array import Array
 from ._concatenate import concatenate_columns, concatenate_rows
 from ._data_frame import DataFrame
+from ._data_type import DataType
 from ._record import Record
 
 DataTable = DataFrame

--- a/src/tabeline/_array.py
+++ b/src/tabeline/_array.py
@@ -3,71 +3,120 @@ from __future__ import annotations
 __all__ = ["Array"]
 
 from collections.abc import Sequence
-from typing import Iterator, overload
+from typing import Generic, Iterator, TypeVar, overload
 
 import numpy as np
 import polars as pl
+from polars.exceptions import InvalidOperationError
+
+from ._data_type import DataType
+
+Element = TypeVar("Element", bound=DataType)
 
 
-class Array(Sequence):
+class Array(Sequence, Generic[Element]):
     @overload
-    def __init__(self, *elements: bool):
+    def __init__(self, *elements: bool | None, data_type: DataType | None = None) -> None:
         pass
 
     @overload
-    def __init__(self, *elements: int):
+    def __init__(self, *elements: int | None, data_type: DataType | None = None) -> None:
         pass
 
     @overload
-    def __init__(self, *elements: float):
+    def __init__(self, *elements: float | int | None, data_type: DataType | None = None) -> None:
         pass
 
     @overload
-    def __init__(self, *elements: str):
+    def __init__(self, *elements: str | None, data_type: DataType | None = None) -> None:
         pass
 
     @overload
-    def __init__(self, elements: pl.Array, /):
+    def __init__(self, elements: pl.Array, /, *, data_type: DataType | None = None) -> None:
         pass
 
-    def __init__(self, *elements):
-        if len(elements) == 1 and isinstance(elements[0], pl.Series):
-            self._array = elements[0]
+    def __init__(self, *elements, data_type: DataType | None = None) -> None:
+        if len(elements) > 0 and isinstance(elements[0], pl.Series):
+            if len(elements) != 1:
+                raise TypeError(
+                    "Passing a Series is the private constructor, "
+                    "which requires exactly one argument"
+                )
+            if data_type is not None:
+                raise TypeError(
+                    "Passing a Series is the private constructor, "
+                    "which does not allow setting the data type"
+                )
+
+            series = elements[0]
+
+            # Extract data type from Polars dtype
+            data_type = DataType.from_polars(series.dtype)
         else:
-            self._array = pl.Series(values=elements)
+            data_type = coerce_default_element_type(default_element_type(elements), data_type)
+            series = pl.Series(values=elements, dtype=data_type.to_polars())
+
+        self.data_type = data_type
+        self._series = series
+
+    @staticmethod
+    def from_sequence(
+        sequence: Sequence[None | bool | int | float | str],
+        /,
+        *,
+        data_type: DataType | None = None,
+    ) -> Array:
+        return Array(*sequence, data_type=data_type)
 
     @staticmethod
     def from_polars(array: pl.Array, /) -> Array:
         return Array(array)
 
     def to_polars(self) -> pl.Array:
-        return self._array
+        return self._series
 
     @staticmethod
     def from_numpy(array: np.ndarray, /) -> Array:
         return Array(pl.Series(values=array))
 
     def to_numpy(self) -> np.ndarray:
-        return self._array.to_numpy()
+        return self._series.to_numpy(use_pyarrow=False)
 
     def __len__(self) -> int:
-        return len(self._array)
+        return len(self._series)
 
     def __getitem__(self, index: int) -> bool | int | float | str:
-        return self._array[index]
+        return self._series[index]
 
     def __iter__(self) -> Iterator[bool | int | float | str]:
-        return iter(self._array)
+        return iter(self._series)
 
     def __eq__(self, other: object) -> bool:
-        # Series equality considers the name of the series, convert to NumPy
-        # array compare just values and also consider NaNs equal.
         if isinstance(other, (Array, pl.Series)):
-            # Exit early on empty arrays to avoid NumPy/ctypes warning in Python 3.9
-            if len(self) == 0 or len(other) == 0:
-                return len(self) == len(other)
+            # Series.series_equal does not consider NaNs equal, so we have to
+            # try to find the NaNs and make those elements equal. But not all
+            # data types support NaNs, so bail when is_nan fails.
 
-            return array_equal(self.to_numpy(), other.to_numpy())
+            self_series = self.to_polars()
+
+            if isinstance(other, Array):
+                other_series = other.to_polars()
+            else:
+                other_series = other
+
+            equal_elements = self_series.eq_missing(other_series)
+
+            try:
+                self_nan = self_series.is_nan().fill_null(False)
+            except InvalidOperationError:
+                return equal_elements.all()
+
+            try:
+                other_nan = other_series.is_nan().fill_null(False)
+            except InvalidOperationError:
+                return equal_elements.all()
+
+            return (equal_elements | (self_nan & other_nan)).all()
         elif isinstance(other, np.ndarray):
             # Exit early on empty arrays to avoid NumPy/ctypes warning in Python 3.9
             if len(self) == 0 or len(other) == 0:
@@ -77,13 +126,24 @@ class Array(Sequence):
         return NotImplemented
 
     def __str__(self) -> str:
-        return "[\n" + "".join(f"    {x}" for x in self._array) + "\n]"
+        return "[\n" + "".join(f"    {x}" for x in self._series) + "\n]"
 
     def __repr__(self) -> str:
-        return f"Array({', '.join(repr(x) for x in self._array)})"
+        return f"Array({', '.join(repr(x) for x in self._series)})"
 
     def __array__(self) -> np.ndarray:
         return self.to_numpy()
+
+    def __class_getitem__(cls, data_type: DataType) -> SpecializedArray:
+        return SpecializedArray(data_type)
+
+
+class SpecializedArray:
+    def __init__(self, data_type: DataType, /) -> None:
+        self.data_type = data_type
+
+    def __call__(self, *elements: object) -> Array:
+        return Array(*elements, data_type=self.data_type)
 
 
 def array_equal(left: np.ndarray, right: np.ndarray) -> bool:
@@ -94,3 +154,106 @@ def array_equal(left: np.ndarray, right: np.ndarray) -> bool:
         return np.array_equal(left, right, equal_nan=True)
     except TypeError:
         return np.array_equal(left, right)
+
+
+def default_element_type(
+    sequence: Sequence[bool | None]
+    | Sequence[int | None]
+    | Sequence[float | int | None]
+    | Sequence[str | None],
+) -> DataType.Boolean | DataType.Integer64 | DataType.Float64 | DataType.String | DataType.Nothing:
+    # Only a subset of data types are possible when converting Python types
+    best_type: (
+        DataType.Boolean
+        | DataType.Integer64
+        | DataType.Float64
+        | DataType.String
+        | DataType.Nothing
+    ) = DataType.Nothing
+
+    for element in sequence:
+        match best_type:
+            case DataType.Nothing:
+                match element:
+                    case None:
+                        pass
+                    case bool():
+                        best_type = DataType.Boolean
+                    case int():
+                        best_type = DataType.Integer64
+                    case float():
+                        best_type = DataType.Float64
+                    case str():
+                        best_type = DataType.String
+                    case _:
+                        raise TypeError(
+                            f"Expected bool, int, float, str, or None, but got {type(element)}: "
+                            f"{element}"
+                        )
+            case DataType.Boolean:
+                match element:
+                    case None | bool():
+                        pass
+                    case _:
+                        raise TypeError(f"Expected bool, but got {type(element)}: {element}")
+            case DataType.Integer64:
+                match element:
+                    case None | int():
+                        pass
+                    case float():
+                        best_type = DataType.Float64
+                    case _:
+                        raise TypeError(f"Expected int, but got {type(element)}: {element}")
+            case DataType.Float64:
+                match element:
+                    case None | int() | float():
+                        pass
+                    case _:
+                        raise TypeError(
+                            f"Expected int or float, but got {type(element)}: {element}"
+                        )
+            case DataType.String:
+                match element:
+                    case None | str():
+                        pass
+                    case _:
+                        raise TypeError(f"Expected str, but got {type(element)}: {element}")
+
+    return best_type
+
+
+def coerce_default_element_type(
+    default: DataType.Boolean
+    | DataType.Integer64
+    | DataType.Float64
+    | DataType.String
+    | DataType.Nothing,
+    given: DataType | None,
+) -> DataType:
+    match default, given:
+        case _, None:
+            return default
+        case DataType.Boolean, DataType.Boolean:
+            return given
+        case (
+            DataType.Integer64,
+            DataType.Integer8
+            | DataType.Integer16
+            | DataType.Integer32
+            | DataType.Integer64
+            | DataType.Whole8
+            | DataType.Whole16
+            | DataType.Whole32
+            | DataType.Whole64
+            | DataType.Float32
+            | DataType.Float64,
+        ):
+            return given
+        case DataType.Float64, DataType.Float32 | DataType.Float64:
+            return given
+        case DataType.String, DataType.String:
+            return given
+        case DataType.Nothing, DataType.Nothing:
+            return given
+        case _:
+            raise TypeError(f"Expected data_type to be compatible with {default}, but got {given}")

--- a/src/tabeline/_array.py
+++ b/src/tabeline/_array.py
@@ -172,52 +172,43 @@ def default_element_type(
     ) = DataType.Nothing
 
     for element in sequence:
-        match best_type:
-            case DataType.Nothing:
-                match element:
-                    case None:
-                        pass
-                    case bool():
-                        best_type = DataType.Boolean
-                    case int():
-                        best_type = DataType.Integer64
-                    case float():
-                        best_type = DataType.Float64
-                    case str():
-                        best_type = DataType.String
-                    case _:
-                        raise TypeError(
-                            f"Expected bool, int, float, str, or None, but got {type(element)}: "
-                            f"{element}"
-                        )
-            case DataType.Boolean:
-                match element:
-                    case None | bool():
-                        pass
-                    case _:
-                        raise TypeError(f"Expected bool, but got {type(element)}: {element}")
-            case DataType.Integer64:
-                match element:
-                    case None | int():
-                        pass
-                    case float():
-                        best_type = DataType.Float64
-                    case _:
-                        raise TypeError(f"Expected int, but got {type(element)}: {element}")
-            case DataType.Float64:
-                match element:
-                    case None | int() | float():
-                        pass
-                    case _:
-                        raise TypeError(
-                            f"Expected int or float, but got {type(element)}: {element}"
-                        )
-            case DataType.String:
-                match element:
-                    case None | str():
-                        pass
-                    case _:
-                        raise TypeError(f"Expected str, but got {type(element)}: {element}")
+        if best_type == DataType.Nothing:
+            if element is None:
+                pass
+            elif isinstance(element, bool):
+                best_type = DataType.Boolean
+            elif isinstance(element, int):
+                best_type = DataType.Integer64
+            elif isinstance(element, float):
+                best_type = DataType.Float64
+            elif isinstance(element, str):
+                best_type = DataType.String
+            else:
+                raise TypeError(
+                    f"Expected bool, int, float, str, or None, but got {type(element)}: {element}"
+                )
+        elif best_type == DataType.Boolean:
+            if element is None or isinstance(element, bool):
+                pass
+            else:
+                raise TypeError(f"Expected bool, but got {type(element)}: {element}")
+        elif best_type == DataType.Integer64:
+            if element is None or isinstance(element, int):
+                pass
+            elif isinstance(element, float):
+                best_type = DataType.Float64
+            else:
+                raise TypeError(f"Expected int, but got {type(element)}: {element}")
+        elif best_type == DataType.Float64:
+            if element is None or isinstance(element, int) or isinstance(element, float):
+                pass
+            else:
+                raise TypeError(f"Expected int or float, but got {type(element)}: {element}")
+        elif best_type == DataType.String:
+            if element is None or isinstance(element, str):
+                pass
+            else:
+                raise TypeError(f"Expected str, but got {type(element)}: {element}")
 
     return best_type
 
@@ -230,30 +221,28 @@ def coerce_default_element_type(
     | DataType.Nothing,
     given: DataType | None,
 ) -> DataType:
-    match default, given:
-        case _, None:
-            return default
-        case DataType.Boolean, DataType.Boolean:
-            return given
-        case (
-            DataType.Integer64,
-            DataType.Integer8
-            | DataType.Integer16
-            | DataType.Integer32
-            | DataType.Integer64
-            | DataType.Whole8
-            | DataType.Whole16
-            | DataType.Whole32
-            | DataType.Whole64
-            | DataType.Float32
-            | DataType.Float64,
-        ):
-            return given
-        case DataType.Float64, DataType.Float32 | DataType.Float64:
-            return given
-        case DataType.String, DataType.String:
-            return given
-        case DataType.Nothing, DataType.Nothing:
-            return given
-        case _:
-            raise TypeError(f"Expected data_type to be compatible with {default}, but got {given}")
+    if given is None:
+        return default
+    elif default == DataType.Boolean and given == DataType.Boolean:
+        return given
+    elif default == DataType.Integer64 and given in [
+        DataType.Integer8,
+        DataType.Integer16,
+        DataType.Integer32,
+        DataType.Integer64,
+        DataType.Whole8,
+        DataType.Whole16,
+        DataType.Whole32,
+        DataType.Whole64,
+        DataType.Float32,
+        DataType.Float64,
+    ]:
+        return given
+    elif default == DataType.Float64 and given in [DataType.Float32, DataType.Float64]:
+        return given
+    elif default == DataType.String and given == DataType.String:
+        return given
+    elif default == DataType.Nothing and given == DataType.Nothing:
+        return given
+    else:
+        raise TypeError(f"Expected data_type to be compatible with {default}, but got {given}")

--- a/src/tabeline/_data_type.py
+++ b/src/tabeline/_data_type.py
@@ -24,61 +24,59 @@ class DataType(Enum):
 
     @staticmethod
     def from_polars(data_type: pl.DataType, /) -> DataType:
-        match data_type:
-            case pl.Boolean:
-                return DataType.Boolean
-            case pl.Int8:
-                return DataType.Integer8
-            case pl.Int16:
-                return DataType.Integer16
-            case pl.Int32:
-                return DataType.Integer32
-            case pl.Int64:
-                return DataType.Integer64
-            case pl.UInt8:
-                return DataType.Whole8
-            case pl.UInt16:
-                return DataType.Whole16
-            case pl.UInt32:
-                return DataType.Whole32
-            case pl.UInt64:
-                return DataType.Whole64
-            case pl.Float32:
-                return DataType.Float32
-            case pl.Float64:
-                return DataType.Float64
-            case pl.Utf8:
-                return DataType.String
-            case pl.Null:
-                return DataType.Nothing
-            case _:
-                raise TypeError(f"Unsupported Polars data type: {data_type}")
+        if data_type == pl.Boolean:
+            return DataType.Boolean
+        elif data_type == pl.Int8:
+            return DataType.Integer8
+        elif data_type == pl.Int16:
+            return DataType.Integer16
+        elif data_type == pl.Int32:
+            return DataType.Integer32
+        elif data_type == pl.Int64:
+            return DataType.Integer64
+        elif data_type == pl.UInt8:
+            return DataType.Whole8
+        elif data_type == pl.UInt16:
+            return DataType.Whole16
+        elif data_type == pl.UInt32:
+            return DataType.Whole32
+        elif data_type == pl.UInt64:
+            return DataType.Whole64
+        elif data_type == pl.Float32:
+            return DataType.Float32
+        elif data_type == pl.Float64:
+            return DataType.Float64
+        elif data_type == pl.Utf8:
+            return DataType.String
+        elif data_type == pl.Null:
+            return DataType.Nothing
+        else:
+            raise TypeError(f"Unsupported Polars data type: {data_type}")
 
     def to_polars(self) -> pl.DataType:
-        match self:
-            case DataType.Boolean:
-                return pl.Boolean()
-            case DataType.Integer8:
-                return pl.Int8()
-            case DataType.Integer16:
-                return pl.Int16()
-            case DataType.Integer32:
-                return pl.Int32()
-            case DataType.Integer64:
-                return pl.Int64()
-            case DataType.Whole8:
-                return pl.UInt8()
-            case DataType.Whole16:
-                return pl.UInt16()
-            case DataType.Whole32:
-                return pl.UInt32()
-            case DataType.Whole64:
-                return pl.UInt64()
-            case DataType.Float32:
-                return pl.Float32()
-            case DataType.Float64:
-                return pl.Float64()
-            case DataType.String:
-                return pl.Utf8()
-            case DataType.Nothing:
-                return pl.Null()
+        if self == DataType.Boolean:
+            return pl.Boolean()
+        elif self == DataType.Integer8:
+            return pl.Int8()
+        elif self == DataType.Integer16:
+            return pl.Int16()
+        elif self == DataType.Integer32:
+            return pl.Int32()
+        elif self == DataType.Integer64:
+            return pl.Int64()
+        elif self == DataType.Whole8:
+            return pl.UInt8()
+        elif self == DataType.Whole16:
+            return pl.UInt16()
+        elif self == DataType.Whole32:
+            return pl.UInt32()
+        elif self == DataType.Whole64:
+            return pl.UInt64()
+        elif self == DataType.Float32:
+            return pl.Float32()
+        elif self == DataType.Float64:
+            return pl.Float64()
+        elif self == DataType.String:
+            return pl.Utf8()
+        elif self == DataType.Nothing:
+            return pl.Null()

--- a/src/tabeline/_data_type.py
+++ b/src/tabeline/_data_type.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+__all__ = ["DataType"]
+
+from enum import Enum, auto
+
+import polars as pl
+
+
+class DataType(Enum):
+    Boolean = auto()
+    Integer8 = auto()
+    Integer16 = auto()
+    Integer32 = auto()
+    Integer64 = auto()
+    Whole8 = auto()
+    Whole16 = auto()
+    Whole32 = auto()
+    Whole64 = auto()
+    Float32 = auto()
+    Float64 = auto()
+    String = auto()
+    Nothing = auto()
+
+    @staticmethod
+    def from_polars(data_type: pl.DataType, /) -> DataType:
+        match data_type:
+            case pl.Boolean:
+                return DataType.Boolean
+            case pl.Int8:
+                return DataType.Integer8
+            case pl.Int16:
+                return DataType.Integer16
+            case pl.Int32:
+                return DataType.Integer32
+            case pl.Int64:
+                return DataType.Integer64
+            case pl.UInt8:
+                return DataType.Whole8
+            case pl.UInt16:
+                return DataType.Whole16
+            case pl.UInt32:
+                return DataType.Whole32
+            case pl.UInt64:
+                return DataType.Whole64
+            case pl.Float32:
+                return DataType.Float32
+            case pl.Float64:
+                return DataType.Float64
+            case pl.Utf8:
+                return DataType.String
+            case pl.Null:
+                return DataType.Nothing
+            case _:
+                raise TypeError(f"Unsupported Polars data type: {data_type}")
+
+    def to_polars(self) -> pl.DataType:
+        match self:
+            case DataType.Boolean:
+                return pl.Boolean()
+            case DataType.Integer8:
+                return pl.Int8()
+            case DataType.Integer16:
+                return pl.Int16()
+            case DataType.Integer32:
+                return pl.Int32()
+            case DataType.Integer64:
+                return pl.Int64()
+            case DataType.Whole8:
+                return pl.UInt8()
+            case DataType.Whole16:
+                return pl.UInt16()
+            case DataType.Whole32:
+                return pl.UInt32()
+            case DataType.Whole64:
+                return pl.UInt64()
+            case DataType.Float32:
+                return pl.Float32()
+            case DataType.Float64:
+                return pl.Float64()
+            case DataType.String:
+                return pl.Utf8()
+            case DataType.Nothing:
+                return pl.Null()

--- a/src/tabeline/_expression/_functions.py
+++ b/src/tabeline/_expression/_functions.py
@@ -62,6 +62,7 @@ built_in_functions: list[Function[Any, Any]] = [
     Function("floor", lambda x: x.floor()),
     Function("ceil", lambda x: x.ceil()),
     # Numeric -> boolean elementwise
+    Function("is_null", lambda x: x.is_null()),
     Function("is_nan", lambda x: x.is_nan()),
     Function("is_finite", lambda x: x.is_finite()),
     # Casting elementwise

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,22 +1,170 @@
+import math
+
 import numpy as np
 import polars as pl
+import pytest
+from polars.testing import assert_series_equal
 
-from tabeline import Array
+from tabeline import Array, DataType
+
+from ._xfail import xfail_param
+
+# Skip some types, otherwise there are too many tests
+numeric_types = [
+    DataType.Integer8,
+    # DataType.Integer16,
+    # DataType.Integer32,
+    DataType.Integer64,
+    DataType.Whole8,
+    # DataType.Whole16,
+    # DataType.Whole32,
+    DataType.Whole64,
+    DataType.Float32,
+    DataType.Float64,
+]
+
+float_types = [
+    DataType.Float32,
+    DataType.Float64,
+]
 
 
-def test_equals():
-    array1 = Array(0, 1, 2)
+@pytest.mark.parametrize(
+    "elements",
+    [
+        [],
+        [0],
+        [None, None, None],
+        [0, None, 2],
+        [True, False, None],
+        [None, "b", "c"],
+        [-math.inf, math.inf, math.nan, None],
+    ],
+)
+def test_equals(elements):
+    array1 = Array(*elements)
+    array2 = Array(*elements)
+    assert array1 == array2
+
+
+def test_not_equal_to_nan():
+    assert Array(0.0, 1.0, None) != Array(0.0, 1.0, math.nan)
+
+
+def test_not_equal_to_null():
+    assert Array(0.0, 1.0, None) != Array(0.0, 1.0, 2.0)
+
+
+@pytest.mark.parametrize("type_1", numeric_types)
+def test_equals_typed_integer_and_untyped(type_1):
+    array1 = Array[type_1](0, 1, 2)
     array2 = Array(0, 1, 2)
     assert array1 == array2
 
 
 def test_polars_equals():
-    array1 = Array(0, 1, 2)
-    array2 = pl.Series([0, 1, 2])
+    array1 = Array(0, 1, None)
+    array2 = pl.Series([0, 1, None])
     assert array1 == array2
 
 
-def test_numpy_equals():
-    array1 = Array(0, 1, 2)
-    array2 = np.array([0, 1, 2])
+@pytest.mark.parametrize(
+    "elements",
+    [[], [0, 1, 2], [-math.inf, math.inf, math.nan], [True, False, True], ["a", "b", "c"]],
+)
+def test_numpy_equals(elements):
+    array1 = Array(*elements)
+    array2 = np.array(elements)
     assert array1 == array2
+
+
+@pytest.mark.parametrize("type_1", float_types)
+def test_equals_typed_float_and_untyped(type_1):
+    # Use simple values that are equal in 32 and 64 bits
+    array1 = Array[type_1](0, 1.5, -2.25)
+    array2 = Array(0, 1.5, -2.25)
+    assert array1 == array2
+
+
+@pytest.mark.parametrize("type_1", numeric_types)
+@pytest.mark.parametrize("type_2", numeric_types)
+def test_equals_typed_integer(type_1, type_2):
+    array1 = Array[type_1](0, 1, 2)
+    array2 = Array[type_2](0, 1, 2)
+    assert array1 == array2
+
+
+@pytest.mark.parametrize("type_1", float_types)
+@pytest.mark.parametrize("type_2", float_types)
+def test_equals_typed_float(type_1, type_2):
+    array1 = Array[type_1](0, 1.5, -2.25)
+    array2 = Array[type_2](0, 1.5, -2.25)
+    assert array1 == array2
+
+
+@pytest.mark.parametrize("elements", [[], [0], [0, 1, 2], [True, False, True], ["a", "b", "c"]])
+def test_array_iter(elements):
+    array = Array(*elements)
+    assert list(array) == elements
+
+
+def test_incompatible_type():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Expected data_type to be compatible with DataType.Integer64, "
+            "but got DataType.String"
+        ),
+    ):
+        _ = Array(0, 1, 2, data_type=DataType.String)
+
+
+@pytest.mark.parametrize(
+    "elements", [xfail_param([]), [0], [0, 1, 2], [True, False, True], ["a", "b", "c"]]
+)
+def test_from(elements):
+    expected = Array(*elements)
+
+    assert expected == Array.from_sequence(elements)
+    assert elements == list(expected)
+
+    series = pl.Series(values=elements)
+    assert expected == Array.from_polars(series)
+    assert_series_equal(series, expected.to_polars())
+
+    numpy_array = np.array(elements)
+    assert expected == Array.from_numpy(numpy_array)
+    assert all(numpy_array == expected.to_numpy())
+
+
+@pytest.mark.parametrize("elements", [[0, None, 2], [None, False, True], ["a", "b", None]])
+def test_from_none(elements):
+    expected = Array(*elements)
+
+    assert expected == Array.from_sequence(elements)
+    assert elements == list(expected)
+
+    series = pl.Series(values=elements)
+    assert expected == Array.from_polars(series)
+    assert series.series_equal(expected.to_polars())
+
+
+@pytest.mark.parametrize("elements", [[], [None, None, None]])
+def test_from_all_nones(elements):
+    # This test is needed because Polars defaults to Float32 instead of Null
+    # when all elements are None
+    expected = Array(*elements)
+
+    assert expected == Array.from_sequence(elements)
+    assert elements == list(expected)
+
+    series = pl.Series(values=elements, dtype=pl.Null)
+    assert expected == Array.from_polars(series)
+    assert series.series_equal(expected.to_polars())
+
+
+def test_str_repr():
+    # Only verify that it doesn't crash
+    array = Array(0, 1, 2)
+    _ = str(array)
+    _ = repr(array)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -14,7 +14,7 @@ zero_argument_functions = [
     "row_index1",
 ]
 
-one_argument_functions = [
+one_argument_elementwise_functions = [
     "abs",
     "sqrt",
     "log",
@@ -29,9 +29,15 @@ one_argument_functions = [
     "arctan",
     "floor",
     "ceil",
-    "is_null",
     "is_nan",
     "is_finite",
+    "to_boolean",
+    "to_integer",
+    "to_float",
+    "to_string",
+]
+
+one_argument_math_reduction_functions = [
     "std",
     "var",
     "max",
@@ -39,15 +45,17 @@ one_argument_functions = [
     "sum",
     "mean",
     "median",
-    "any",
-    "all",
+]
+
+one_argument_functions = [
+    *one_argument_elementwise_functions,
+    "is_null",
     "first",
     "last",
+    "any",
+    "all",
     "same",
-    "to_boolean",
-    "to_integer",
-    "to_float",
-    "to_string",
+    *one_argument_math_reduction_functions,
 ]
 
 
@@ -72,10 +80,17 @@ one_argument_functions = [
 )
 def test_single_numeric_argument_against_python(name, function):
     values = [0.5, 1.0, math.pi / 4]
-    df = DataFrame(x=values)
+    df = DataFrame(x=[*values, None])
     actual = df.transmute(y=f"{name}(x)")
-    expected = DataFrame(y=[function(value) for value in values])
+    expected = DataFrame(y=[function(value) for value in values] + [None])
     assert_data_frame_equal(actual, expected, reltol=1e-8)
+
+
+@pytest.mark.parametrize("name", one_argument_elementwise_functions)
+def test_null_propagation_in_broadcast(name):
+    df = DataFrame(x=[1.0, 2.0, None])
+    actual = df.transmute(y=f"{name}(x)")
+    assert actual[2, "y"] is None
 
 
 @pytest.mark.parametrize("name", zero_argument_functions)
@@ -208,24 +223,40 @@ def test_cast_string(values):
     assert actual == expected
 
 
+@pytest.mark.parametrize("function", one_argument_math_reduction_functions)
+def test_math_reduction_functions(function):
+    df = DataFrame(x=[1, 1, 1, 2, 2, 2, 2], y=[1, 2, 3, 4, 5, 6, None])
+    actual = df.group_by("x").summarize(y=f"{function}(y)").transmute(x="x", test="is_null(y)")
+    assert actual == DataFrame(x=[1, 2], test=[False, True])
+
+
 def test_quantile():
-    actual = DataFrame(x=[20, 21, 22]).mutate(q="quantile(x, 0.75)")
-    expected = DataFrame(x=[20, 21, 22], q=[21.5, 21.5, 21.5])
+    actual = (
+        DataFrame(x=[0, 0, 0, 1, 1, 1], y=[20, 21, 22, None, 21, 22])
+        .group_by("x")
+        .summarize(q="quantile(y, 0.75)")
+    )
+    expected = DataFrame(x=[0, 1], q=[21.5, None])
     assert_data_frame_equal(actual, expected, reltol=1e-8)
 
 
-def test_same():
-    df = DataFrame(a=[0, 0, 1], x=[True, True, False], y=[-1, -1, 2], z=["aa", "aa", "bb"])
-    actual = df.group_by("a").summarize(x="same(x)", y="same(y)", z="same(z)")
-    expected = DataFrame(a=[0, 1], x=[True, False], y=[-1, 2], z=["aa", "bb"])
+@pytest.mark.parametrize(
+    "values",
+    [[True, True, False], [-1, -1, 2], ["aa", "aa", "bb"], [None, None, 1], [None, None, None]],
+)
+def test_same(values):
+    df = DataFrame(a=[0, 0, 1], x=values)
+    actual = df.group_by("a").summarize(x="same(x)")
+    expected = DataFrame(a=[0, 1], x=values[1:])
     assert actual == expected
 
 
-def test_same_error():
-    df = DataFrame(a=[0, 0, 1], x=[True, True, False], y=[-1, -1, 2], z=["aa", "bb", "bb"])
+@pytest.mark.parametrize("values", [[0, 1, 2], [0.0, 1.0, 2.0], ["a", "b", "c"], [1, None, 2]])
+def test_same_error(values):
+    df = DataFrame(a=[0, 0, 1], x=values)
     # PanicException because Polars eats the SameError
     with pytest.raises(PolarsPanicError):
-        _ = df.group_by("a").summarize(x="same(x)", y="same(y)", z="same(z)")
+        _ = df.group_by("a").summarize(x="same(x)")
 
 
 @pytest.mark.skip("Parser does not support array literals")
@@ -241,19 +272,19 @@ def test_interp():
 
 def test_interp_reduce():
     df = DataFrame(
-        id=[1, 1, 1, 2, 2, 2],
-        ts=[1.2, 2.5, 3.4, 2.0, 3.0, 10.3],
-        ys=[0.3, 0.1, 0.8, 1.0, 0.8, 0.1],
+        id=[1, 1, 1, 2, 2, 2, 3, 3, 3],
+        ts=[1.2, 2.5, 3.4, 2.0, 3.0, 10.3, 1.0, 2.0, 3.0],
+        ys=[0.3, 0.1, 0.8, 1.0, 0.8, 0.1, 2.0, 3.0, None],
     )
     actual = df.group_by("id").summarize(y="interp(2.5, ts, ys)")
-    expected = DataFrame(id=[1, 2], y=[0.1, 0.9])
+    expected = DataFrame(id=[1, 2, 3], y=[0.1, 0.9, None])
     assert_data_frame_equal(actual, expected, reltol=1e-8)
 
 
 def test_trapz():
-    df = DataFrame(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4])
+    df = DataFrame(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, None])
     actual = df.group_by("id").summarize(q="trapz(t, y)")
-    expected = DataFrame(id=[0, 1], q=[2.0, 13.0])
+    expected = DataFrame(id=[0, 1], q=[2.0, None])
     assert_data_frame_equal(actual, expected, reltol=1e-8)
 
 
@@ -300,4 +331,38 @@ def test_if_else_grouped_no_otherwise():
 def test_if_else_on_rowless_data_frame_with_mutate(default, df):
     actual = df.mutate(x=f"if_else(a!=0, a{default})")
     expected = df.mutate(x="1")
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([True, True, True], True),
+        ([False, True, False], True),
+        ([False, False, False], False),
+        ([True, False, None], True),
+        ([False, False, None], None),
+    ],
+)
+def test_any(values, expected):
+    df = DataFrame(x=[0, 0, 0], y=values)
+    actual = df.group_by("x").summarize(y="any(y)")
+    expected = DataFrame(x=[0], y=[expected])
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([True, True, True], True),
+        ([False, True, False], False),
+        ([False, False, False], False),
+        ([True, True, None], None),
+        ([False, True, None], False),
+    ],
+)
+def test_all(values, expected):
+    df = DataFrame(x=[0, 0, 0], y=values)
+    actual = df.group_by("x").summarize(y="all(y)")
+    expected = DataFrame(x=[0], y=[expected])
     assert actual == expected

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -29,6 +29,7 @@ one_argument_functions = [
     "arctan",
     "floor",
     "ceil",
+    "is_null",
     "is_nan",
     "is_finite",
     "std",
@@ -135,6 +136,13 @@ def test_one_argument_functions_on_rowless_data_frame_with_mutate(name, df):
 
     actual = df.mutate(x=f"{name}(a)")
     expected = df.mutate(x="1")
+    assert actual == expected
+
+
+def test_is_null():
+    df = DataFrame(a=[0.0, math.nan, None])
+    actual = df.transmute(b="is_null(a)")
+    expected = DataFrame(b=[False, False, True])
     assert actual == expected
 
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -58,3 +58,21 @@ def test_comparison_operators(left, right, operator, comparer):
     actual = df.transmute(output=f"left {operator} right")
     expected = DataFrame(output=[comparer(left, right)])
     assert actual == expected
+
+
+@pytest.mark.parametrize("elements", [(1, 2), (1.0, 2.0)])
+@pytest.mark.parametrize("operator", ["+", "-", "*", "/", "**", ">=", "<=", ">", "<"])
+def test_null_propogation_in_math(elements, operator):
+    df = DataFrame(left=[*elements, None, None], right=[elements[0], None, elements[1], None])
+    actual = df.transmute(output=f"left {operator} right").slice1([2, 3, 4])
+    expected = DataFrame(output=[None, None, None])
+    assert actual == expected
+
+
+@pytest.mark.parametrize("elements", [(True, False), (1, 2), (1.0, 2.0), ("a", "b")])
+@pytest.mark.parametrize("operator", ["==", "!="])
+def test_null_propogation_in_equality(elements, operator):
+    df = DataFrame(left=[*elements, None, None], right=[elements[0], None, elements[1], None])
+    actual = df.transmute(output=f"left {operator} right").slice1([2, 3, 4])
+    expected = DataFrame(output=[None, None, None])
+    assert actual == expected


### PR DESCRIPTION
This also adds `tabeline.DataType`, which has boolean, integer, float, and string types. These types map one-to-one onto Polars types. `Array`s are now generic in this type.