### PR TITLE
Fix single-element string arrays

### DIFF
--- a/src/py_scalar.rs
+++ b/src/py_scalar.rs
@@ -114,6 +114,8 @@ impl From<AnyValue<'_>> for PyScalar {
             AnyValue::Float32(value) => PyScalar::Float(value as f64),
             AnyValue::Float64(value) => PyScalar::Float(value),
             AnyValue::String(value) => PyScalar::String(value.to_owned()),
+            // WORKAROUND: Series.from_iter generates owned strings when given a list of length 1
+            AnyValue::StringOwned(value) => PyScalar::String(value.into()),
             any_value => panic!("Unsupported data type: {:?}", any_value.dtype()),
         }
     }

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -149,6 +149,12 @@ def test_get_item():
     assert array[2] is None
 
 
+def test_get_one_item():
+    # Polars behaves differently on single-element string arrays
+    array = Array("a")
+    assert array[0] == "a"
+
+
 @pytest.mark.parametrize(
     "elements",
     [[], [0], [0, 1, 2], [True, False, True], ["a", "b", "c"], [None, None, None]],


### PR DESCRIPTION
Polars behaves differently when constructing a Series with one string element vs all other states. This handles that case.